### PR TITLE
Update PostgreSQL version to 13.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   db:
-    image: postgres:10.3-alpine
+    image: postgres:13.2-alpine
     ports:
       - "5432:5432"
     environment:
@@ -19,7 +19,7 @@ services:
     command: ["-addr", "0.0.0.0:8222"]
 
   upstream_db:
-    image: postgres:10.3-alpine
+    image: postgres:13.2-alpine
     ports:
       - "5433:5432"
     environment:


### PR DESCRIPTION
Fixes #55.

This PR updates PostgreSQL to version 13.2, keeping up with the changes in Automattic/ccsearch-catalog#54.