### PR TITLE
Ingestion server Docker improvements

### DIFF
--- a/ingestion_server/README.md
+++ b/ingestion_server/README.md
@@ -121,6 +121,6 @@ database_table_to_elasticsearch_model = {
 
 This codebase is deployed as Docker image to Docker hub. The deployed image is then pulled in the production environment. See the [`./publish_release.sh`](publish_release.sh) script for deploying to Docker hub. The machine running the script must be logged into Docker as the Openverse account.
 
-The current docker hub image is at [openverse/ingestion_server](https://hub.docker.com/r/openverse/ingestion_server) but the image previously lived at [creativecommons/ingestion_server](https://hub.docker.com/r/creativecommons/ingestion_server).
+The current Docker hub image is at [openverse/ingestion_server](https://hub.docker.com/r/openverse/ingestion_server) but the image previously lived at [creativecommons/ingestion_server](https://hub.docker.com/r/creativecommons/ingestion_server).
 
 The version numbering for the Docker image appears to be a standalone semver value, seperate from the repository version.

--- a/ingestion_server/README.md
+++ b/ingestion_server/README.md
@@ -119,6 +119,8 @@ database_table_to_elasticsearch_model = {
 
 # Deployment (last deployed version: 1.20.0)
 
-This docker image is deployed to docker hub. The deployed image is pulled in our production environment. See the [`./publish_release.sh`](publish_release.sh) script for deploying to docker hub. The current docker hub image is [openverse/ingestion_server](https://hub.docker.com/r/openverse/ingestion_server) but the image previously lived at [creativecommons/ingestion_server](https://hub.docker.com/r/creativecommons/ingestion_server)
+This codebase is deployed as Docker image to Docker hub. The deployed image is then pulled in the production environment. See the [`./publish_release.sh`](publish_release.sh) script for deploying to Docker hub. The machine running the script must be logged into Docker as the Openverse account.
 
-The version numbering for the docker image is seemigly a standalone semver system, distinct from the repository.
+The current docker hub image is at [openverse/ingestion_server](https://hub.docker.com/r/openverse/ingestion_server) but the image previously lived at [creativecommons/ingestion_server](https://hub.docker.com/r/creativecommons/ingestion_server).
+
+The version numbering for the Docker image appears to be a standalone semver value, seperate from the repository version.

--- a/ingestion_server/README.md
+++ b/ingestion_server/README.md
@@ -123,4 +123,4 @@ This codebase is deployed as Docker image to Docker hub. The deployed image is t
 
 The current Docker hub image is at [openverse/ingestion_server](https://hub.docker.com/r/openverse/ingestion_server) but the image previously lived at [creativecommons/ingestion_server](https://hub.docker.com/r/creativecommons/ingestion_server).
 
-The version numbering for the Docker image appears to be a standalone semver value, seperate from the repository version.
+The version numbering for the Docker image appears to be a standalone semver value, separate from the repository version.

--- a/ingestion_server/README.md
+++ b/ingestion_server/README.md
@@ -116,3 +116,9 @@ database_table_to_elasticsearch_model = {
     'image': Image
 }
 ```
+
+# Deployment (last deployed version: 1.20.0)
+
+This docker image is deployed to docker hub. The deployed image is pulled in our production environment. See the [`./publish_release.sh`](publish_release.sh) script for deploying to docker hub. The current docker hub image is [openverse/ingestion_server](https://hub.docker.com/r/openverse/ingestion_server) but the image previously lived at [creativecommons/ingestion_server](https://hub.docker.com/r/creativecommons/ingestion_server)
+
+The version numbering for the docker image is seemigly a standalone semver system, distinct from the repository.

--- a/ingestion_server/publish_release.sh
+++ b/ingestion_server/publish_release.sh
@@ -1,5 +1,5 @@
 # Usage: ./public_release.sh [VERSION]
-docker build -t creativecommons/ingestion_server:$1 .
-docker build -f Dockerfile-worker -t creativecommons/indexer_worker:$1 .
-docker push creativecommons/ingestion_server:$1
-docker push creativecommons/indexer_worker:$1
+docker build -t openverse/ingestion_server:$1 .
+docker build -f Dockerfile-worker -t openverse/indexer_worker:$1 .
+docker push openverse/ingestion_server:$1
+docker push openverse/indexer_worker:$1


### PR DESCRIPTION
- Switch from `creativecommons` to `openverse` docker hub account
- Add documentation about deploying the ingestion server to docker in the ingestion server README