### PR TITLE
URL renames for Openverse API

### DIFF
--- a/DOCUMENTATION_GUIDELINES.md
+++ b/DOCUMENTATION_GUIDELINES.md
@@ -167,7 +167,7 @@ Code examples on how to use the API endpoints. The current API documentation pro
 image_stats_bash = \
   """
   # Get a list of content providers and their image count
-  curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" http://api.creativecommons.engineering/v1/sources
+  curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" http://api.openverse.engineering/v1/sources
   """  # noqa
 
 @swagger_auto_schema(operation_id='image_stats',

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository is primarily concerned with back end infrastructure like datasto
 
 ## API Documentation
 
-In the [API documentation](https://api.creativecommons.engineering), you can find more details about the endpoints with examples on how to use them.
+In the [API documentation](https://api.openverse.engineering), you can find more details about the endpoints with examples on how to use them.
 
 ## How to Run the Server Locally
 
@@ -94,7 +94,7 @@ Every week, the latest version of the data is automatically bulk copied ("ingest
 
 ### Description of subprojects
 
-- _openverse-api_ is a Django Rest Framework API server. For a full description of its capabilities, please see the [browsable documentation](https://api.creativecommons.engineering).
+- _openverse-api_ is a Django Rest Framework API server. For a full description of its capabilities, please see the [browsable documentation](https://api.openverse.engineering).
 - _ingestion-server_ is a service for downloading and indexing search data once it has been prepared by the Openverse Catalog
 - _analytics_ is a Falcon REST API for collecting usage data.
 

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -49,7 +49,7 @@ root path (e.g. localhost:8090/). You may have to tweak `docs/redoc.html` for
 this to work on your local machine.
 
 Alternatively, you can view the production version of the documentation at
-`https://api.creativecommons.engineering/analytics`.
+`https://api.openverse.engineering/analytics`.
 
 ## Contributing / Code Structure
 

--- a/analytics/docs/redoc.html
+++ b/analytics/docs/redoc.html
@@ -18,7 +18,7 @@
     </style>
   </head>
   <body>
-    <redoc spec-url='https://api.creativecommons.engineering/analytics/swagger.yaml'></redoc>
+    <redoc spec-url='https://api.openverse.engineering/analytics/swagger.yaml'></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
   </body>
 </html>

--- a/analytics/docs/swagger.yaml
+++ b/analytics/docs/swagger.yaml
@@ -3,13 +3,13 @@ info:
   description: "An API for registering anonymous usage data events in CC Search, which we intend to use to improve the quality of the search results."
   version: "1.0.0"
   title: "CC Search Usage Data API"
-  termsOfService: "https://api.creativecommons.engineering/terms_of_service.html"
+  termsOfService: "https://api.openverse.engineering/terms_of_service.html"
   contact:
     email: "alden@creativecommons.org"
   license:
     name: "MIT License"
     url: "https://github.com/wordpress/openverse-api/blob/master/LICENSE"
-host: "api.creativecommons.engineering"
+host: "api.openverse.engineering"
 basePath: "/analytics"
 tags:
 - name: "Register events"
@@ -185,4 +185,4 @@ definitions:
 
 externalDocs:
   description: "The Creative Commons search API"
-  url: "https://api.creativecommons.engineering"
+  url: "https://api.openverse.engineering"

--- a/openverse-api/catalog/api/views/image_views.py
+++ b/openverse-api/catalog/api/views/image_views.py
@@ -109,31 +109,31 @@ class SearchImages(APIView):
     image_search_bash = \
         """
         # Example 1: Search for an exact match of Claude Monet
-        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" https://api.creativecommons.engineering/v1/images?q="Claude Monet"
+        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" https://api.openverse.engineering/v1/images?q="Claude Monet"
         
         # Example 2: Search for images related to both dog and cat
-        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" https://api.creativecommons.engineering/v1/images?q=dog+cat
+        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" https://api.openverse.engineering/v1/images?q=dog+cat
         
         # Example 3: Search for images related to dog or cat, but not necessarily both
-        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" https://api.creativecommons.engineering/v1/images?q=dog|cat
+        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" https://api.openverse.engineering/v1/images?q=dog|cat
 
         # Example 4: Search for images related to dog but won't include results related to 'pug'
-        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" https://api.creativecommons.engineering/v1/images?q=dog -pug
+        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" https://api.openverse.engineering/v1/images?q=dog -pug
         
         # Example 5: Search for images matching anything with the prefix ‘net’
-        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" https://api.creativecommons.engineering/v1/images?q=net*
+        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" https://api.openverse.engineering/v1/images?q=net*
         
         # Example 6: Search for images that match dogs that are either corgis or labrador
-        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" https://api.creativecommons.engineering/v1/images?q=dogs + (corgis | labrador)
+        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" https://api.openverse.engineering/v1/images?q=dogs + (corgis | labrador)
         
         # Example 7: Search for images that match strings close to the term theater with a difference of one character
-        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" https://api.creativecommons.engineering/v1/images?q=theatre~1
+        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" https://api.openverse.engineering/v1/images?q=theatre~1
         
         # Example 8: Search for images using single query parameter
-        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" https://api.creativecommons.engineering/v1/images?q=test
+        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" https://api.openverse.engineering/v1/images?q=test
         
         # Example 9: Search for images using multiple query parameters
-        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" https://api.creativecommons.engineering/v1/images?q=test&license=pdm,by&categories=illustration&page_size=1&page=1   
+        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" https://api.openverse.engineering/v1/images?q=test&license=pdm,by&categories=illustration&page_size=1&page=1   
         """  # noqa
 
     @swagger_auto_schema(operation_id='image_search',
@@ -221,7 +221,7 @@ class RelatedImage(APIView):
     recommendations_images_read_bash = \
         """
         # Get related images for image ID (7c829a03-fb24-4b57-9b03-65f43ed19395)
-        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" http://api.creativecommons.engineering/v1/recommendations/images/7c829a03-fb24-4b57-9b03-65f43ed19395
+        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" http://api.openverse.engineering/v1/recommendations/images/7c829a03-fb24-4b57-9b03-65f43ed19395
         """  # noqa
 
     @swagger_auto_schema(operation_id="recommendations_images_read",
@@ -299,7 +299,7 @@ class ImageDetail(GenericAPIView, RetrieveModelMixin):
     image_detail_bash = \
         """
         # Get the details of image ID (7c829a03-fb24-4b57-9b03-65f43ed19395)
-        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" http://api.creativecommons.engineering/v1/images/7c829a03-fb24-4b57-9b03-65f43ed19395
+        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" http://api.openverse.engineering/v1/images/7c829a03-fb24-4b57-9b03-65f43ed19395
         """  # noqa
 
     @swagger_auto_schema(operation_id="image_detail",
@@ -430,7 +430,7 @@ class OembedView(APIView):
     oembed_list_bash = \
         """
         # Retrieve embedded content from image URL (https://ccsearch.creativecommons.org/photos/7c829a03-fb24-4b57-9b03-65f43ed19395)
-        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" http://api.creativecommons.engineering/v1/oembed?url=https://ccsearch.creativecommons.org/photos/7c829a03-fb24-4b57-9b03-65f43ed19395
+        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" http://api.openverse.engineering/v1/oembed?url=https://ccsearch.creativecommons.org/photos/7c829a03-fb24-4b57-9b03-65f43ed19395
         """  # noqa
 
     @swagger_auto_schema(operation_id="oembed_list",

--- a/openverse-api/catalog/api/views/site_views.py
+++ b/openverse-api/catalog/api/views/site_views.py
@@ -94,7 +94,7 @@ class ImageStats(APIView):
     image_stats_bash = \
         """
         # Get a list of content providers and their image count
-        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" http://api.creativecommons.engineering/v1/sources
+        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" http://api.openverse.engineering/v1/sources
         """  # noqa
 
     @swagger_auto_schema(operation_id='image_stats',
@@ -171,7 +171,7 @@ class Register(APIView):
     register_api_oauth2_bash = \
         """
         # Register for a key
-        curl -X POST -H "Content-Type: application/json" -d '{"name": "My amazing project", "description": "To access CC Catalog API", "email": "openverse-api@creativecommons.org"}' https://api.creativecommons.engineering/v1/auth_tokens/register
+        curl -X POST -H "Content-Type: application/json" -d '{"name": "My amazing project", "description": "To access CC Catalog API", "email": "openverse-api@creativecommons.org"}' https://api.openverse.engineering/v1/auth_tokens/register
         """  # noqa
 
     register_api_oauth2_request = openapi.Schema(
@@ -354,7 +354,7 @@ class CheckRates(APIView):
     key_info_bash = \
         """
         # Get information about your API key
-        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" http://api.creativecommons.engineering/v1/rate_limit
+        curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" http://api.openverse.engineering/v1/rate_limit
         """  # noqa
 
     @swagger_auto_schema(operation_id='key_info',

--- a/openverse-api/catalog/example_responses.py
+++ b/openverse-api/catalog/example_responses.py
@@ -18,15 +18,15 @@ image_search_200_example = {
                 "creator": "en:User:Oil&GasIndustry",
                 "creator_url": "https://en.wikipedia.org/wiki/User:Oil%26GasIndustry",
                 "url": "https://upload.wikimedia.org/wikipedia/commons/3/3a/Well_test_separator.svg",
-                "thumbnail": "https://api.creativecommons.engineering/v1/thumbs/36537842-b067-4ca0-ad67-e00ff2e06b2d",
+                "thumbnail": "https://api.openverse.engineering/v1/thumbs/36537842-b067-4ca0-ad67-e00ff2e06b2d",
                 "provider": "wikimedia",
                 "source": "wikimedia",
                 "license": "by",
                 "license_version": "3.0",
                 "license_url": "https://creativecommons.org/licenses/by/3.0",
                 "foreign_landing_url": "https://commons.wikimedia.org/w/index.php?curid=26229990",
-                "detail_url": "http://api.creativecommons.engineering/v1/images/36537842-b067-4ca0-ad67-e00ff2e06b2d",
-                "related_url": "http://api.creativecommons.engineering/v1/recommendations/images/36537842-b067-4ca0-ad67-e00ff2e06b2d",
+                "detail_url": "http://api.openverse.engineering/v1/images/36537842-b067-4ca0-ad67-e00ff2e06b2d",
+                "related_url": "http://api.openverse.engineering/v1/recommendations/images/36537842-b067-4ca0-ad67-e00ff2e06b2d",
                 "fields_matched": [
                     "description",
                     "title"
@@ -61,15 +61,15 @@ image_detail_200_example = {
             }
         ],
         "url": "https://live.staticflickr.com/5122/5264886972_3234d62748.jpg",
-        "thumbnail": "https://api.creativecommons.engineering/v1/thumbs/7c829a03-fb24-4b57-9b03-65f43ed19395",
+        "thumbnail": "https://api.openverse.engineering/v1/thumbs/7c829a03-fb24-4b57-9b03-65f43ed19395",
         "provider": "flickr",
         "source": "flickr",
         "license": "by",
         "license_version": "2.0",
         "license_url": "https://creativecommons.org/licenses/by/2.0/",
         "foreign_landing_url": "https://www.flickr.com/photos/18090920@N07/5264886972",
-        "detail_url": "http://api.creativecommons.engineering/v1/images/7c829a03-fb24-4b57-9b03-65f43ed19395",
-        "related_url": "http://api.creativecommons.engineering/v1/recommendations/images/7c829a03-fb24-4b57-9b03-65f43ed19395",
+        "detail_url": "http://api.openverse.engineering/v1/images/7c829a03-fb24-4b57-9b03-65f43ed19395",
+        "related_url": "http://api.openverse.engineering/v1/recommendations/images/7c829a03-fb24-4b57-9b03-65f43ed19395",
         "height": 167,
         "width": 500,
         "attribution": "\"exam test\" by Sean MacEntee is licensed under CC-BY 2.0. To view a copy of this license, visit https://creativecommons.org/licenses/by/2.0/"
@@ -144,15 +144,15 @@ recommendations_images_read_200_example = {
                     }
                 ],
                 "url": "https://live.staticflickr.com/4065/4459771899_07595dc42e.jpg",
-                "thumbnail": "https://api.creativecommons.engineering/v1/thumbs/610756ec-ae31-4d5e-8f03-8cc52f31b71d",
+                "thumbnail": "https://api.openverse.engineering/v1/thumbs/610756ec-ae31-4d5e-8f03-8cc52f31b71d",
                 "provider": "flickr",
                 "source": "flickr",
                 "license": "by",
                 "license_version": "2.0",
                 "license_url": "https://creativecommons.org/licenses/by/2.0/",
                 "foreign_landing_url": "https://www.flickr.com/photos/18090920@N07/4459771899",
-                "detail_url": "http://api.creativecommons.engineering/v1/images/610756ec-ae31-4d5e-8f03-8cc52f31b71d",
-                "related_url": "http://api.creativecommons.engineering/v1/recommendations/images/610756ec-ae31-4d5e-8f03-8cc52f31b71d"
+                "detail_url": "http://api.openverse.engineering/v1/images/610756ec-ae31-4d5e-8f03-8cc52f31b71d",
+                "related_url": "http://api.openverse.engineering/v1/recommendations/images/610756ec-ae31-4d5e-8f03-8cc52f31b71d"
             }
         ]
     }

--- a/openverse-api/catalog/scripts/api_load_testing/locustfile.py
+++ b/openverse-api/catalog/scripts/api_load_testing/locustfile.py
@@ -24,7 +24,7 @@ class BrowseResults(TaskSet):
     @task(10)
     def shorten_link(self):
         _unique = str(uuid.uuid4())
-        image_link = "http://api-dev.creativecommons.engineering/list/{}"\
+        image_link = "http://dev.api.openverse.engineering/list/{}"\
             .format(_unique)
         self.client.post("/link", {"full_url": image_link})
 

--- a/openverse-api/catalog/scripts/migration/migrate_lists.py
+++ b/openverse-api/catalog/scripts/migration/migrate_lists.py
@@ -17,7 +17,7 @@ def import_lists_to_catalog(parsed_lists):
             'images': _list['images']
         }
         response = requests.post(
-            'http://api.creativecommons.engineering/list',
+            'http://api.openverse.engineering/list',
             data=payload
         )
         if 300 > response.status_code >= 200:

--- a/openverse-api/catalog/scripts/thumbnail_load_test/locustfile.py
+++ b/openverse-api/catalog/scripts/thumbnail_load_test/locustfile.py
@@ -31,7 +31,7 @@ successful vs failed thumbnails.
 
 Optionally rerun the test after the cache has been warmed up.
 """
-PROXY_URL = "https://api-dev.creativecommons.engineering/t/600/"
+PROXY_URL = "https://dev.api.openverse.engineering/t/600/"
 
 url_queue = gevent.queue.Queue()
 provider_counts = defaultdict(int)

--- a/openverse-api/catalog/settings.py
+++ b/openverse-api/catalog/settings.py
@@ -33,14 +33,14 @@ SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
 DEBUG = os.environ.get('DJANGO_DEBUG_ENABLED', default=False) in true_strings
 
 ALLOWED_HOSTS = ['localhost', '127.0.0.1', os.environ.get('LOAD_BALANCER_URL'),
-                 'api-dev.creativecommons.engineering',
-                 "api.creativecommons.engineering",
+                 'dev.api.openverse.engineering',
+                 "api.openverse.engineering",
                  gethostname(), gethostbyname(gethostname())]
 
 # Domains that shortened links may point to
 SHORT_URL_WHITELIST = {
-    'api-dev.creativecommons.engineering',
-    'api.creativecommons.engineering',
+    'dev.api.openverse.engineering',
+    'api.openverse.engineering',
     'ccccatalog.herokuapp.com',
     'ccsearch.creativecommons.org',
     'localhost:8000'
@@ -167,7 +167,7 @@ THUMBNAIL_PROXY_URL = os.environ.get(
 )
 # Proxy insecure HTTP images through our internal proxy.
 DETAIL_PROXY_URL = os.environ.get(
-    'DETAIL_PROXY_URL', 'https://api.creativecommons.engineering/t'
+    'DETAIL_PROXY_URL', 'https://api.openverse.engineering/t'
 )
 
 THUMBNAIL_WIDTH_PX = 600

--- a/openverse-api/catalog/urls.py
+++ b/openverse-api/catalog/urls.py
@@ -60,7 +60,7 @@ This can be done using the `/v1/auth_tokens/register` endpoint.
 Example on how to register for a key
 
 ```
-$ curl -X POST -H "Content-Type: application/json" -d '{"name": "My amazing project", "description": "To access CC Catalog API", "email": "openverse-api@creativecommons.org"}' https://api.creativecommons.engineering/v1/auth_tokens/register
+$ curl -X POST -H "Content-Type: application/json" -d '{"name": "My amazing project", "description": "To access CC Catalog API", "email": "openverse-api@creativecommons.org"}' https://api.openverse.engineering/v1/auth_tokens/register
 ```
 
 <br>
@@ -86,7 +86,7 @@ This can be done by exchanging your client credentials for a token using the \
 Example on how to authenticate using OAuth2
 
 ```
-$ curl -X POST -d "client_id=pm8GMaIXIhkjQ4iDfXLOvVUUcIKGYRnMlZYApbda&client_secret=YhVjvIBc7TuRJSvO2wIi344ez5SEreXLksV7GjalLiKDpxfbiM8qfUb5sNvcwFOhBUVzGNdzmmHvfyt6yU3aGrN6TAbMW8EOkRMOwhyXkN1iDetmzMMcxLVELf00BR2e&grant_type=client_credentials" https://api.creativecommons.engineering/v1/auth_tokens/token/
+$ curl -X POST -d "client_id=pm8GMaIXIhkjQ4iDfXLOvVUUcIKGYRnMlZYApbda&client_secret=YhVjvIBc7TuRJSvO2wIi344ez5SEreXLksV7GjalLiKDpxfbiM8qfUb5sNvcwFOhBUVzGNdzmmHvfyt6yU3aGrN6TAbMW8EOkRMOwhyXkN1iDetmzMMcxLVELf00BR2e&grant_type=client_credentials" https://api.openverse.engineering/v1/auth_tokens/token/
 ```
 
 <br>
@@ -114,7 +114,7 @@ your future API requests.
 Example
 
 ```
-$ curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" https://api.creativecommons.engineering/v1/images?q=test
+$ curl -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" https://api.openverse.engineering/v1/images?q=test
 ```
 <br>
 <blockquote>
@@ -166,7 +166,7 @@ We love pull requests! If you’re interested in [contributing on Github](https:
 """  # noqa
 
 logo_url = "https://mirrors.creativecommons.org/presskit/logos/cc.logo.svg"
-tos_url = "https://api.creativecommons.engineering/terms_of_service.html"
+tos_url = "https://api.openverse.engineering/terms_of_service.html"
 license_url =\
     "https://github.com/wordpress/openverse-api/blob/master/LICENSE"
 schema_view = get_schema_view(
@@ -189,7 +189,7 @@ schema_view = get_schema_view(
 report_image_bash = \
     """
     # Report an issue about image ID (7c829a03-fb24-4b57-9b03-65f43ed19395)
-    curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" -d '{"reason": "mature", "identifier": "7c829a03-fb24-4b57-9b03-65f43ed19395", "description": "This image contains sensitive content"}' https://api.creativecommons.engineering/v1/images/7c829a03-fb24-4b57-9b03-65f43ed19395/report
+    curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer DLBYIcfnKfolaXKcmMC8RIDCavc2hW" -d '{"reason": "mature", "identifier": "7c829a03-fb24-4b57-9b03-65f43ed19395", "description": "This image contains sensitive content"}' https://api.openverse.engineering/v1/images/7c829a03-fb24-4b57-9b03-65f43ed19395/report
     """  # noqa
 
 report_image_request = openapi.Schema(

--- a/openverse-api/test/api_live_integration_test.py
+++ b/openverse-api/test/api_live_integration_test.py
@@ -18,8 +18,8 @@ designed. Run with the `pytest -s` command from this directory.
 API_URL = os.getenv('INTEGRATION_TEST_URL', 'http://localhost:8000')
 known_apis = {
     'http://localhost:8000': 'LOCAL',
-    'https://api.creativecommons.engineering': 'PRODUCTION',
-    'https://api-dev.creativecommons.engineering': 'TESTING'
+    'https://api.openverse.engineering': 'PRODUCTION',
+    'https://dev.api.openverse.engineering': 'TESTING'
 }
 
 

--- a/openverse-api/test/api_live_search_qa.py
+++ b/openverse-api/test/api_live_search_qa.py
@@ -8,7 +8,7 @@ documents in the search index, so toy examples with five or six documents
 do not accurately model relevance at scale.
 """
 
-API_URL = 'https://api-dev.creativecommons.engineering'
+API_URL = 'https://dev.api.openverse.engineering'
 
 
 def _phrase_in_tags(tags, term):

--- a/openverse-api/test/v1_integration_test.py
+++ b/openverse-api/test/v1_integration_test.py
@@ -21,8 +21,8 @@ designed. Run with the `pytest -s` command from this directory.
 API_URL = os.getenv('INTEGRATION_TEST_URL', 'http://localhost:8000')
 known_apis = {
     'http://localhost:8000': 'LOCAL',
-    'https://api.creativecommons.engineering': 'PRODUCTION',
-    'https://api-dev.creativecommons.engineering': 'TESTING'
+    'https://api.openverse.engineering': 'PRODUCTION',
+    'https://dev.api.openverse.engineering': 'TESTING'
 }
 
 


### PR DESCRIPTION
This PR rewrites two URLs: 

- `api-dev.creativecommons.engineering` ~> `dev.api.openverse.engineering`
- `api.creativecommons.engineering` ~> `api.openverse.engineering`