### PR TITLE
Small email address and directory name typo fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Any code modifications will have to be accompanied by the appropriate unit tests
 
 You can check the health of a live deployment of the API by running the live integration tests.
 
-1. Change directory to `copenverse-api`
+1. Change directory to `openverse-api`
 
 ```
 cd openverse-api

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Any code modifications will have to be accompanied by the appropriate unit tests
 
 You can check the health of a live deployment of the API by running the live integration tests.
 
-1. Change directory to `cccatalog-api`
+1. Change directory to `copenverse-api`
 
 ```
 cd openverse-api

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,4 +1,4 @@
-# cccatalog-api contributors (sorted alphabetically by last name)
+# copenverse-api contributors (sorted alphabetically by last name)
 
 - **[Liza Daley](https://github.com/lizadaly)**
   - Built CC Search prototype, bits of which live on in this repository to this day

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,4 +1,4 @@
-# copenverse-api contributors (sorted alphabetically by last name)
+# openverse-api contributors (sorted alphabetically by last name)
 
 - **[Liza Daley](https://github.com/lizadaly)**
   - Built CC Search prototype, bits of which live on in this repository to this day

--- a/DOCUMENTATION_GUIDELINES.md
+++ b/DOCUMENTATION_GUIDELINES.md
@@ -145,7 +145,7 @@ register_api_oauth2_request = openapi.Schema(
   example={
     "name": "My amazing project",
     "description": "To access CC Catalog API",
-    "email": "cccatalog-api@creativecommons.org"
+    "email": "czack.krida@automattic.com"
   }
 )
 

--- a/DOCUMENTATION_GUIDELINES.md
+++ b/DOCUMENTATION_GUIDELINES.md
@@ -145,7 +145,7 @@ register_api_oauth2_request = openapi.Schema(
   example={
     "name": "My amazing project",
     "description": "To access CC Catalog API",
-    "email": "czack.krida@automattic.com"
+    "email": "zack.krida@automattic.com"
   }
 )
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You need to install [Docker](https://docs.docker.com/install/) (with [Docker Com
 git clone https://github.com/WordPress/openverse-api.git
 ```
 
-4. Change directories with `cd copenverse-api`
+4. Change directories with `cd openverse-api`
 5. Start Openverse API locally by running the docker containers
 
 ```
@@ -38,7 +38,7 @@ docker-compose up
 7. Open up your browser and type `localhost:8000` in the search tab
 8. Make sure you see the local API documentation
    ![Local API Documentation](local_api_documentation.PNG)
-9. Open a new CMD or terminal and change directory to `copenverse-api`
+9. Open a new CMD or terminal and change directory to `openverse-api`
 10. Still in the new CMD or terminal, load the sample data. This script requires a local postgres installation to connect to and alter our database.
 
 ```
@@ -104,10 +104,10 @@ Every week, the latest version of the data is automatically bulk copied ("ingest
 
 You can check the health of a live deployment of the API by running the live integration tests.
 
-1. Change directory to the `copenverse-api`
+1. Change directory to the `openverse-api`
 
 ```
-cd copenverse-api
+cd openverse-api
 ```
 
 #### On the host

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You need to install [Docker](https://docs.docker.com/install/) (with [Docker Com
 git clone https://github.com/WordPress/openverse-api.git
 ```
 
-4. Change directories with `cd cccatalog-api`
+4. Change directories with `cd copenverse-api`
 5. Start Openverse API locally by running the docker containers
 
 ```
@@ -38,7 +38,7 @@ docker-compose up
 7. Open up your browser and type `localhost:8000` in the search tab
 8. Make sure you see the local API documentation
    ![Local API Documentation](local_api_documentation.PNG)
-9. Open a new CMD or terminal and change directory to `cccatalog-api`
+9. Open a new CMD or terminal and change directory to `copenverse-api`
 10. Still in the new CMD or terminal, load the sample data. This script requires a local postgres installation to connect to and alter our database.
 
 ```
@@ -104,10 +104,10 @@ Every week, the latest version of the data is automatically bulk copied ("ingest
 
 You can check the health of a live deployment of the API by running the live integration tests.
 
-1. Change directory to the `cccatalog-api`
+1. Change directory to the `copenverse-api`
 
 ```
-cd cccatalog-api
+cd copenverse-api
 ```
 
 #### On the host

--- a/analytics/docs/swagger.yaml
+++ b/analytics/docs/swagger.yaml
@@ -5,7 +5,7 @@ info:
   title: "CC Search Usage Data API"
   termsOfService: "https://api.creativecommons.engineering/terms_of_service.html"
   contact:
-    email: "alden@creativecommons.org"
+    email: "zack.krida@automattic.com"
   license:
     name: "MIT License"
     url: "https://github.com/wordpress/openverse-api/blob/master/LICENSE"

--- a/openverse-api/catalog/api/views/site_views.py
+++ b/openverse-api/catalog/api/views/site_views.py
@@ -171,7 +171,7 @@ class Register(APIView):
     register_api_oauth2_bash = \
         """
         # Register for a key
-        curl -X POST -H "Content-Type: application/json" -d '{"name": "My amazing project", "description": "To access CC Catalog API", "email": "openverse-api@creativecommons.org"}' https://api.creativecommons.engineering/v1/auth_tokens/register
+        curl -X POST -H "Content-Type: application/json" -d '{"name": "My amazing project", "description": "To access CC Catalog API", "email": "zack.krida@automattic.com"}' https://api.creativecommons.engineering/v1/auth_tokens/register
         """  # noqa
 
     register_api_oauth2_request = openapi.Schema(
@@ -210,7 +210,7 @@ class Register(APIView):
         example={
             "name": "My amazing project",
             "description": "To access CC Catalog API",
-            "email": "openverse-api@creativecommons.org"
+            "email": "zack.krida@automattic.com"
         }
     )
 

--- a/openverse-api/catalog/urls.py
+++ b/openverse-api/catalog/urls.py
@@ -60,7 +60,7 @@ This can be done using the `/v1/auth_tokens/register` endpoint.
 Example on how to register for a key
 
 ```
-$ curl -X POST -H "Content-Type: application/json" -d '{"name": "My amazing project", "description": "To access CC Catalog API", "email": "openverse-api@creativecommons.org"}' https://api.creativecommons.engineering/v1/auth_tokens/register
+$ curl -X POST -H "Content-Type: application/json" -d '{"name": "My amazing project", "description": "To access CC Catalog API", "email": "zack.krida@automattic.com"}' https://api.creativecommons.engineering/v1/auth_tokens/register
 ```
 
 <br>
@@ -174,7 +174,7 @@ schema_view = get_schema_view(
         title="Creative Commons Catalog API",
         default_version=API_VERSION,
         description=description,
-        contact=openapi.Contact(email="openverse-api@creativecommons.org"),
+        contact=openapi.Contact(email="zack.krida@automattic.com"),
         license=openapi.License(name="MIT License", url=license_url),
         terms_of_service=tos_url,
         x_logo={


### PR DESCRIPTION
Small email address and directory name typo fixes: 

- Replace all referenced email addresses with `zack.krida@automattic.com` for now.
- `ccatalog-*` ~> `openverse-*`