### PR TITLE
Domain hotfix

### DIFF
--- a/openverse-api/catalog/scripts/api_load_testing/locustfile.py
+++ b/openverse-api/catalog/scripts/api_load_testing/locustfile.py
@@ -24,7 +24,7 @@ class BrowseResults(TaskSet):
     @task(10)
     def shorten_link(self):
         _unique = str(uuid.uuid4())
-        image_link = "http://dev.api.openverse.engineering/list/{}"\
+        image_link = "http://api-dev.openverse.engineering/list/{}"\
             .format(_unique)
         self.client.post("/link", {"full_url": image_link})
 

--- a/openverse-api/catalog/scripts/thumbnail_load_test/locustfile.py
+++ b/openverse-api/catalog/scripts/thumbnail_load_test/locustfile.py
@@ -31,7 +31,7 @@ successful vs failed thumbnails.
 
 Optionally rerun the test after the cache has been warmed up.
 """
-PROXY_URL = "https://dev.api.openverse.engineering/t/600/"
+PROXY_URL = "https://api-dev.openverse.engineering/t/600/"
 
 url_queue = gevent.queue.Queue()
 provider_counts = defaultdict(int)

--- a/openverse-api/catalog/settings.py
+++ b/openverse-api/catalog/settings.py
@@ -33,13 +33,13 @@ SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
 DEBUG = os.environ.get('DJANGO_DEBUG_ENABLED', default=False) in true_strings
 
 ALLOWED_HOSTS = ['localhost', '127.0.0.1', os.environ.get('LOAD_BALANCER_URL'),
-                 'dev.api.openverse.engineering',
+                 'api-dev.openverse.engineering',
                  "api.openverse.engineering",
                  gethostname(), gethostbyname(gethostname())]
 
 # Domains that shortened links may point to
 SHORT_URL_WHITELIST = {
-    'dev.api.openverse.engineering',
+    'api-dev.openverse.engineering',
     'api.openverse.engineering',
     'ccccatalog.herokuapp.com',
     'ccsearch.creativecommons.org',

--- a/openverse-api/test/api_live_integration_test.py
+++ b/openverse-api/test/api_live_integration_test.py
@@ -19,7 +19,7 @@ API_URL = os.getenv('INTEGRATION_TEST_URL', 'http://localhost:8000')
 known_apis = {
     'http://localhost:8000': 'LOCAL',
     'https://api.openverse.engineering': 'PRODUCTION',
-    'https://dev.api.openverse.engineering': 'TESTING'
+    'https://api-dev.openverse.engineering': 'TESTING'
 }
 
 

--- a/openverse-api/test/api_live_search_qa.py
+++ b/openverse-api/test/api_live_search_qa.py
@@ -8,7 +8,7 @@ documents in the search index, so toy examples with five or six documents
 do not accurately model relevance at scale.
 """
 
-API_URL = 'https://dev.api.openverse.engineering'
+API_URL = 'https://api-dev.openverse.engineering'
 
 
 def _phrase_in_tags(tags, term):

--- a/openverse-api/test/v1_integration_test.py
+++ b/openverse-api/test/v1_integration_test.py
@@ -22,7 +22,7 @@ API_URL = os.getenv('INTEGRATION_TEST_URL', 'http://localhost:8000')
 known_apis = {
     'http://localhost:8000': 'LOCAL',
     'https://api.openverse.engineering': 'PRODUCTION',
-    'https://dev.api.openverse.engineering': 'TESTING'
+    'https://api-dev.openverse.engineering': 'TESTING'
 }
 
 


### PR DESCRIPTION
Quick fix to replace the `dev.api.openverse.engineering` with `api-dev.openverse.engineering` because Cloudflare SSL doesn't work on nested subdomains (i.e `sub.sub.sub.domain.com`).