### PR TITLE
Update release-drafter.yml

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - $default-branch
+      - main
 
 jobs:
   update_release_draft:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - develop
+      - $default-branch
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
Fix release drafter to run on the primary branch.

Note: the `$default-branch` variable doesn't work in workflows, but it works in workflow _templates_.

https://stackoverflow.com/a/65723433/3433762