### PR TITLE
Replace deprecated `falcon.API` with `falcon.App`

### DIFF
--- a/analytics/server.py
+++ b/analytics/server.py
@@ -83,7 +83,7 @@ cors = CORS(
     allow_all_methods=True,
     allow_all_headers=True
 )
-api = falcon.API(middleware=[cors.middleware])
+api = falcon.App(middleware=[cors.middleware])
 api.add_route('/', RedocResource())
 api.add_route('/swagger.yaml', OpenAPISpecResource())
 api.add_route('/search_event', SearchEventResource())

--- a/ingestion_server/ingestion_server/api.py
+++ b/ingestion_server/ingestion_server/api.py
@@ -169,7 +169,7 @@ def create_api(log=True):
         handler.setFormatter(formatter)
         root.addHandler(handler)
 
-    _api = falcon.API()
+    _api = falcon.App()
     task_tracker = TaskTracker()
     task_resource = TaskResource(task_tracker)
     get_task_status = TaskStatus(task_tracker)

--- a/ingestion_server/ingestion_server/indexer_worker.py
+++ b/ingestion_server/ingestion_server/indexer_worker.py
@@ -112,6 +112,6 @@ formatter = log.Formatter(
 )
 handler.setFormatter(formatter)
 root.addHandler(handler)
-api = falcon.API()
+api = falcon.App()
 api.add_route('/indexing_task', IndexingJobResource())
 api.add_route('/healthcheck', HealthcheckResource())


### PR DESCRIPTION
Fixes #114 

Falcon version 3.0 deprecated `falcon.API` class, and replaced it with `falcon.App`. This PR uses the new way of creating the falcon App.