### PR TITLE
Replace `string.format()` with `fstrings`

### DIFF
--- a/ingestion_server/ingestion_server/api.py
+++ b/ingestion_server/ingestion_server/api.py
@@ -57,7 +57,7 @@ class TaskResource:
         request_error = self._validate_create_task(raw_body)
         if request_error:
             logging.warning(
-                'Invalid request made. Reason: {}'.format(request_error)
+                f'Invalid request made. Reason: {request_error}'
             )
             resp.status = falcon.HTTP_400
             resp.media = {
@@ -88,7 +88,7 @@ class TaskResource:
         task_id = self.tracker \
             .add_task(task, task_id, action, progress, finish_time)
         base_url = self._get_base_url(req)
-        status_url = base_url + '/task/{}'.format(task_id)
+        status_url = f"{base_url}/task/{task_id}"
         # Give the task a moment to start so we can detect immediate failure.
         # TODO: Use IPC to detect if the job launched successfully instead
         # of giving it 100ms to crash. This is prone to race conditions.

--- a/ingestion_server/ingestion_server/distributed_reindex_scheduler.py
+++ b/ingestion_server/ingestion_server/distributed_reindex_scheduler.py
@@ -81,7 +81,7 @@ def _prepare_workers():
         _id = instance['InstanceId']
         servers.append(server)
         ids.append(_id)
-    log.info('Selected worker instances {}'.format(servers))
+    log.info(f'Selected worker instances {servers}')
     client.start_instances(InstanceIds=ids)
     return servers
 

--- a/ingestion_server/ingestion_server/indexer.py
+++ b/ingestion_server/ingestion_server/indexer.py
@@ -154,8 +154,8 @@ def get_last_item_ids(table):
     # Find the last row added to the database table
     cur.execute(
         SQL(
-            'SELECT id, identifier FROM {} ORDER BY id DESC LIMIT 1;'
-        ).format(Identifier(table))
+            f'SELECT id, identifier FROM {Identifier(table)} ORDER BY id DESC LIMIT 1;'
+        )
     )
     last_added_pg_id, last_added_uuid = cur.fetchone()
     cur.close()
@@ -180,7 +180,7 @@ class TableIndexer:
         """
         last_pg_id, _ = get_last_item_ids(table)
         if not last_pg_id:
-            log.warning('Tried to sync ' + table + ' but it was empty.')
+            log.warning(f'Tried to sync {table} but it was empty.')
             return
         # Find the last document inserted into elasticsearch
         destination = dest_idx if dest_idx else table
@@ -195,8 +195,7 @@ class TableIndexer:
                      'Replicating everything.')
             last_es_id = 0
         log.info(
-            'highest_db_id, highest_es_id: {}, {}'
-            .format(last_pg_id, last_es_id)
+            f'highest_db_id, highest_es_id: {last_pg_id}, {last_es_id}'
         )
         # Select all documents in-between and replicate to Elasticsearch.
         if last_pg_id > last_es_id:
@@ -265,8 +264,8 @@ class TableIndexer:
                 if not chunk:
                     break
                 log.info(
-                    'PSQL indexer down: batch_size={}, downloaded_per_second={}'
-                    .format(len(chunk), dl_rate)
+                    f'PSQL indexer down: batch_size={len(chunk)}, '
+                    f'downloaded_per_second={dl_rate}'
                 )
                 es_batch = self.pg_chunk_to_es(
                     pg_chunk=chunk,
@@ -276,7 +275,7 @@ class TableIndexer:
                 )
                 push_start_time = time.time()
                 num_docs = len(es_batch)
-                log.info('Pushing {} docs to Elasticsearch.'.format(num_docs))
+                log.info(f'Pushing {num_docs} docs to Elasticsearch.')
                 # Bulk upload to Elasticsearch in parallel.
                 try:
                     self._bulk_upload(es_batch)
@@ -285,16 +284,16 @@ class TableIndexer:
                 upload_time = time.time() - push_start_time
                 upload_rate = len(es_batch) / upload_time
                 log.info(
-                    'Elasticsearch up: batch_size={}, uploaded_per_second={}'
-                    .format(len(es_batch), upload_rate)
+                    f'Elasticsearch up: batch_size={len(es_batch)},'
+                    f' uploaded_per_second={upload_rate}'
                 )
                 num_converted_documents += len(chunk)
                 total_indexed_so_far += len(chunk)
                 if self.progress is not None:
                     self.progress.value = \
                         (total_indexed_so_far / num_to_index) * 100
-            log.info('Synchronized ' + str(num_converted_documents) + ' from '
-                     'table \'' + table + '\' to Elasticsearch')
+            log.info(f"Synchronized {num_converted_documents} from "
+                     f"table '{table}' to Elasticsearch")
             if self.finish_time is not None:
                 self.finish_time.value = \
                     datetime.datetime.utcnow().timestamp()
@@ -376,16 +375,14 @@ class TableIndexer:
             }
             es.indices.update_aliases(index_update)
             log.info(
-                'Updated \'{}\' index alias to point to {}'
-                .format(live_alias, write_index)
+                f"Updated '{live_alias}' index alias to point to {write_index}"
             )
-            log.info('Deleting old index {}'.format(old))
+            log.info(f'Deleting old index {old}')
             es.indices.delete(index=old)
         else:
             es.indices.put_alias(index=write_index, name=live_alias)
             log.info(
-                'Created \'{}\' index alias pointing to {}'
-                .format(live_alias, write_index)
+                f"Created '{live_alias}' index alias pointing to {write_index}"
             )
 
     def listen(self, poll_interval=10):
@@ -424,11 +421,11 @@ class TableIndexer:
 
     def update(self, model_name: str, since_date):
         log.info(
-            'Updating index {} with changes since {}'
-            .format(model_name, since_date)
+            f'Updating index {model_name} with changes since {since_date}'
         )
-        query = SQL('SELECT * FROM {} WHERE updated_on >= \'{}\''
-                    .format(model_name, since_date))
+        query = SQL(
+            f"SELECT * FROM {model_name} WHERE updated_on >= '{since_date}'"
+        )
         self.replicate(model_name, model_name, query)
 
     @staticmethod
@@ -490,7 +487,7 @@ if __name__ == '__main__':
     elasticsearch = elasticsearch_connect()
     syncer = TableIndexer(elasticsearch, replicate_tables)
     if parsed.reindex:
-        log.info('Reindexing {}'.format(parsed.reindex))
+        log.info(f'Reindexing {parsed.reindex}')
         syncer.reindex(parsed.reindex)
     elif parsed.update:
         index, date = parsed.update

--- a/ingestion_server/ingestion_server/indexer_worker.py
+++ b/ingestion_server/ingestion_server/indexer_worker.py
@@ -62,7 +62,7 @@ def _execute_indexing_task(target_index, start_id, end_id, notify_url):
                 FROM image
                 WHERE id BETWEEN {start_id} AND {end_id}
                 ''')
-    log.info('Querying {}'.format(query))
+    log.info(f'Querying {query}')
     indexer = TableIndexer(
         elasticsearch, table, progress, finish_time
     )

--- a/ingestion_server/ingestion_server/tasks.py
+++ b/ingestion_server/ingestion_server/tasks.py
@@ -107,7 +107,7 @@ class Task(Process):
             indexer.reindex(self.model)
         elif self.task_type == TaskTypes.LOAD_TEST_DATA:
             indexer.load_test_data()
-        logging.info('Task {} exited.'.format(self.task_id))
+        logging.info(f'Task {self.task_id} exited.')
         if self.callback_url:
             try:
                 requests.post(self.callback_url)

--- a/openverse-api/catalog/api/models/media.py
+++ b/openverse-api/catalog/api/models/media.py
@@ -99,11 +99,11 @@ class AbstractMedia(OpenLedgerModel):
         _license = str(self.license)
         license_version = str(self.license_version)
         if self.title:
-            title = '"' + str(self.title) + '"'
+            title = f'"{self.title}"'
         else:
             title = 'This work'
         if self.creator:
-            creator = 'by ' + str(self.creator) + ' '
+            creator = f'by {self.creator} '
         else:
             creator = ''
         attribution = ATTRIBUTION.format(

--- a/openverse-api/catalog/api/serializers/image_serializers.py
+++ b/openverse-api/catalog/api/serializers/image_serializers.py
@@ -21,7 +21,7 @@ def _validate_lt(value):
     for _type in license_types:
         if _type not in license_helpers.LICENSE_GROUPS:
             raise serializers.ValidationError(
-                "License type \'{}\' does not exist.".format(_type)
+                f"License type '{_type}' does not exist."
             )
         license_groups.append(license_helpers.LICENSE_GROUPS[_type])
     intersected = set.intersection(*license_groups)
@@ -51,7 +51,7 @@ def _validate_li(value):
     for _license in licenses:
         if _license not in license_helpers.LICENSE_GROUPS['all']:
             raise serializers.ValidationError(
-                "License \'{}\' does not exist.".format(_license)
+                f"License '{_license}' does not exist."
             )
     return value.lower()
 
@@ -75,15 +75,14 @@ class ImageSearchQueryStringSerializer(serializers.Serializer):
     license = serializers.CharField(
         label="licenses",
         help_text="A comma-separated list of licenses. Example: `by,cc0`."
-                  " Valid inputs: `{}`"
-                  .format(list(license_helpers.LICENSE_GROUPS['all'])),
+                  " Valid inputs: "
+                  f"`{list(license_helpers.LICENSE_GROUPS['all'])}`",
         required=False,
     )
     license_type = serializers.CharField(
         label="license type",
-        help_text="A list of license types. "
-                  "Valid inputs: `{}`"
-                  .format((list(license_helpers.LICENSE_GROUPS.keys()))),
+        help_text="A list of license types. Valid inputs: "
+                  f"`{list(license_helpers.LICENSE_GROUPS.keys())}`",
         required=False,
     )
     page = serializers.IntegerField(
@@ -125,7 +124,7 @@ class ImageSearchQueryStringSerializer(serializers.Serializer):
         label="provider",
         help_text="A comma separated list of data sources to search. Valid "
                   "inputs:"
-                  " `{}`".format(list(get_sources('image').keys())),
+                  f" `{list(get_sources('image').keys())}`",
         required=False
     )
     extension = serializers.CharField(
@@ -264,7 +263,7 @@ def _add_protocol(url: str):
     """
     parsed = urlparse(url)
     if parsed.scheme == '':
-        return 'https://' + url
+        return f'https://{url}'
     else:
         return url
 

--- a/openverse-api/catalog/api/serializers/link_serializers.py
+++ b/openverse-api/catalog/api/serializers/link_serializers.py
@@ -36,9 +36,8 @@ class ShortenedLinkSerializer(ModelSerializer):
     full_url = serializers.URLField(
         max_length=1000,
         help_text="The URL to shorten. Only URLs on the CC Catalog domain will"
-                  " be accepted. Valid domains: `{}`. "
-                  "Valid paths: `{}`".format(settings.SHORT_URL_WHITELIST,
-                                             settings.SHORT_URL_PATH_WHITELIST)
+                  f" be accepted. Valid domains: `{settings.SHORT_URL_WHITELIST}`. "
+                  f"Valid paths: `{settings.SHORT_URL_PATH_WHITELIST}`"
     )
 
     class Meta:
@@ -62,9 +61,8 @@ class ShortenedLinkSerializer(ModelSerializer):
 
         if not found_allowed_path:
             raise ValidationError(
-                "Illegal path. Valid paths must start with {}".format(
-                    str(settings.SHORT_URL_PATH_WHITELIST)
-                )
+                "Illegal path. Valid paths must start with"
+                f" {settings.SHORT_URL_PATH_WHITELIST}"
             )
 
         return value

--- a/openverse-api/catalog/api/utils/ccrel.py
+++ b/openverse-api/catalog/api/utils/ccrel.py
@@ -33,7 +33,7 @@ def embed_xmp_bytes(image: io.BytesIO, work_properties):
     # `io.BytesIO` object, we have to use a temporary file and then convert it
     # back.
     # https://github.com/python-xmp-toolkit/python-xmp-toolkit/issues/46
-    filename = '/tmp/{}'.format(uuid.uuid4())
+    filename = f'/tmp/{uuid.uuid4()}'
     with open(filename, 'w+b') as xmp_temp:
         xmp_temp.write(image.getvalue())
         xmp_temp.flush()

--- a/openverse-api/catalog/api/utils/validate_images.py
+++ b/openverse-api/catalog/api/utils/validate_images.py
@@ -81,12 +81,12 @@ def validate_images(query_hash, start_slice, results, image_urls):
         if status == 429 or status == 403:
             log.warning(
                 'Image validation failed due to rate limiting or blocking. '
-                'Affected URL: {}'.format(image_urls[idx])
+                f'Affected URL: {image_urls[idx]}'
             )
         elif status != 200:
             log.info(
-                'Deleting broken image with ID {} from results.'
-                .format(results[del_idx]['identifier'])
+                f"Deleting broken image with ID "
+                f"{results[del_idx]['identifier']} from results."
             )
             del results[del_idx]
             new_mask[del_idx] = 0
@@ -98,8 +98,8 @@ def validate_images(query_hash, start_slice, results, image_urls):
     save_query_mask(query_hash, new_mask)
 
     end_time = time.time()
-    log.info('Validated images in {} '.format(end_time - start_time))
+    log.info(f'Validated images in {end_time - start_time} ')
 
 
 def _validation_failure(request, exception):
-    log.warning('Failed to validate image! Reason: {}'.format(exception))
+    log.warning(f'Failed to validate image! Reason: {exception}')

--- a/openverse-api/catalog/api/utils/watermark.py
+++ b/openverse-api/catalog/api/utils/watermark.py
@@ -125,12 +125,9 @@ def _full_license(image_info):
 
     license_name = image_info['license'].upper()
     license_version = image_info['license_version'].upper()
+    prefix = '' if license_name == 'CC0' else 'CC '
 
-    return '{prefix}{name} {version}'.format(
-        prefix='' if license_name == 'CC0' else 'CC ',
-        name=license_name,
-        version=license_version
-    )
+    return f'{prefix}{license_name} {license_version}'
 
 
 def _get_attribution_text(image_info):
@@ -145,13 +142,7 @@ def _get_attribution_text(image_info):
     full_license = _full_license(image_info)
 
     return (
-        '"{title}" '
-        'by {creator} '
-        'is licensed under {full_license}.'
-    ).format(
-        title=title,
-        creator=creator,
-        full_license=full_license,
+        f'"{title}" by {creator} is licensed under {full_license}.'
     )
 
 

--- a/openverse-api/catalog/api/views/image_views.py
+++ b/openverse-api/catalog/api/views/image_views.py
@@ -387,8 +387,7 @@ class Watermark(GenericAPIView):
             except (libxmp.XMPError, AttributeError) as e:
                 # Just send the EXIF-ified file if libxmp fails to add metadata.
                 log.error(
-                    'Failed to add XMP metadata to {}'
-                    .format(image_record.identifier)
+                    f'Failed to add XMP metadata to {image_record.identifier}'
                 )
                 log.error(e)
                 response = HttpResponse(content_type='image/jpeg')

--- a/openverse-api/catalog/api/views/site_views.py
+++ b/openverse-api/catalog/api/views/site_views.py
@@ -434,21 +434,16 @@ class ProxiedImage(APIView):
             return Response(status=404, data='Not Found')
 
         if serialized.data['full_size']:
-            proxy_upstream = '{proxy_url}/{original}'.format(
-                proxy_url=THUMBNAIL_PROXY_URL, original=image.url
-            )
+            proxy_upstream = f'{THUMBNAIL_PROXY_URL}/{image.url}'
         else:
-            proxy_upstream = '{proxy_url}/{width},fit/{original}'.format(
-                proxy_url=THUMBNAIL_PROXY_URL,
-                width=THUMBNAIL_WIDTH_PX,
-                original=image.url
-            )
+            proxy_upstream = f'{THUMBNAIL_PROXY_URL}/{THUMBNAIL_WIDTH_PX}'\
+                             f',fit/{image.url}'
         try:
             upstream_response = urlopen(proxy_upstream)
             status = upstream_response.status
             content_type = upstream_response.headers.get('Content-Type')
         except HTTPError:
-            log.info(f'Failed to render thumbnail: ', exc_info=True)
+            log.info('Failed to render thumbnail: ', exc_info=True)
             return HttpResponse(status=500)
 
         response = HttpResponse(

--- a/openverse-api/catalog/scripts/api_load_testing/locustfile.py
+++ b/openverse-api/catalog/scripts/api_load_testing/locustfile.py
@@ -9,7 +9,7 @@ class BrowseResults(TaskSet):
     def view_image(self):
         if self.parent.results:
             image_id = random.choice(self.parent.results)['id']
-            self.client.get("/image/{}".format(image_id), name="/image/[id]")
+            self.client.get(f"/image/{image_id}", name="/image/[id]")
 
     @task(10)
     def favorite_images(self):
@@ -24,8 +24,7 @@ class BrowseResults(TaskSet):
     @task(10)
     def shorten_link(self):
         _unique = str(uuid.uuid4())
-        image_link = "http://api-dev.openverse.engineering/list/{}"\
-            .format(_unique)
+        image_link = f"http://api-dev.openverse.engineering/list/{_unique}"
         self.client.post("/link", {"full_url": image_link})
 
 
@@ -46,7 +45,7 @@ class UserBehavior(TaskSet):
         query = ','.join(query)
         self.query = query
         response = self.client.get(
-            "/image/search?q={}".format(query),
+            f"/image/search?q={query}",
             name="/image/search?q=[keywords]"
         )
         self.results = json.loads(response.content.decode("utf-8"))['results']

--- a/openverse-api/catalog/scripts/migration/migrate_lists.py
+++ b/openverse-api/catalog/scripts/migration/migrate_lists.py
@@ -30,7 +30,7 @@ def import_lists_to_catalog(parsed_lists):
             # isn't accepted in the new API. Skip over them and log it.
             errors.append((_list['title'], response.text))
             continue
-    log.info('Migrated {} lists successfully'.format(success))
+    log.info(f'Migrated {success} lists successfully')
     if errors:
         log.error("The following errors occurred:")
         for error in errors:

--- a/openverse-api/test/api_live_integration_test.py
+++ b/openverse-api/test/api_live_integration_test.py
@@ -26,13 +26,13 @@ known_apis = {
 def setup_module():
     if API_URL in known_apis:
         print(
-            '\n\033[1;31;40mTesting {} environment'.format(known_apis[API_URL])
+            f'\n\033[1;31;40mTesting {known_apis[API_URL]} environment'
         )
 
 
 @pytest.fixture
 def search_fixture():
-    response = requests.get(API_URL + '/image/search?q=honey',
+    response = requests.get(f'{API_URL}/image/search?q=honey',
                             verify=False)
     assert response.status_code == 200
     parsed = json.loads(response.text)
@@ -43,7 +43,7 @@ def test_search_quotes():
     """
     We want to return a response even if the user messes up quote matching.
     """
-    response = requests.get(API_URL + '/image/search?q="test', verify=False)
+    response = requests.get(f'{API_URL}/image/search?q="test"', verify=False)
     assert response.status_code == 200
 
 
@@ -60,7 +60,7 @@ def test_search_consistency():
     """
     n_pages = 5
     searches = set(
-        requests.get(API_URL + '/image/search?q=honey;page={}'.format(page),
+        requests.get(f'{API_URL}/image/search?q=honey;page={page}',
                      verify=False)
         for page in range(1, n_pages)
     )
@@ -76,7 +76,7 @@ def test_search_consistency():
 
 def test_image_detail(search_fixture):
     test_id = search_fixture['results'][0]['id']
-    response = requests.get(API_URL + '/image/{}'.format(test_id), verify=False)
+    response = requests.get(f'{API_URL}/image/{test_id}', verify=False)
     assert response.status_code == 200
 
 
@@ -106,7 +106,7 @@ def test_image_delete(search_fixture):
 def link_shortener_fixture(search_fixture):
     link_to_shorten = search_fixture['results'][0]['detail']
     payload = {"full_url": link_to_shorten}
-    response = requests.post(API_URL + '/link', json=payload, verify=False)
+    response = requests.post(f'{API_URL}/link', json=payload, verify=False)
     assert response.status_code == 200
     return json.loads(response.text)
 
@@ -117,13 +117,13 @@ def test_link_shortener_create(link_shortener_fixture):
 
 def test_link_shortener_resolve(link_shortener_fixture):
     path = link_shortener_fixture['shortened_url'].split('/')[-1]
-    response = requests.get(API_URL + '/link/' + path, allow_redirects=False,
+    response = requests.get(f'{API_URL}/link/{path}', allow_redirects=False,
                             verify=False)
     assert response.status_code == 301
 
 
 def test_stats():
-    response = requests.get(API_URL + '/statistics/image', verify=False)
+    response = requests.get(f'{API_URL}/statistics/image', verify=False)
     parsed_response = json.loads(response.text)
     assert response.status_code == 200
     num_images = 0
@@ -153,7 +153,7 @@ def test_list_create(search_fixture):
 def test_list_detail(test_list_create):
     list_slug = test_list_create['url'].split('/')[-1]
     response = requests.get(
-        API_URL + '/list/{}'.format(list_slug), verify=False
+        f'{API_URL}/list/{list_slug}', verify=False
     )
     assert response.status_code == 200
 
@@ -162,9 +162,9 @@ def test_list_detail(test_list_create):
 def test_list_delete(test_list_create):
     list_slug = test_list_create['url'].split('/')[-1]
     token = test_list_create['auth']
-    headers = {"Authorization": "Token {}".format(token)}
+    headers = {"Authorization": f"Token {token}"}
     response = requests.delete(
-        API_URL + '/list/{}'.format(list_slug),
+        f'{API_URL}/list/{list_slug}',
         headers=headers,
         verify=False
     )
@@ -179,7 +179,7 @@ def test_license_type_filtering():
     modification = LICENSE_GROUPS['modification']
     commercial_and_modification = set.intersection(modification, commercial)
     response = requests.get(
-        API_URL + '/image/search?q=honey&lt=commercial,modification', verify=False
+        f'{API_URL}/image/search?q=honey&lt=commercial,modification', verify=False
     )
     parsed = json.loads(response.text)
     for result in parsed['results']:
@@ -189,7 +189,7 @@ def test_license_type_filtering():
 def test_single_license_type_filtering():
     commercial = LICENSE_GROUPS['commercial']
     response = requests.get(
-        API_URL + '/image/search?q=honey&lt=commercial', verify=False
+        f'{API_URL}/image/search?q=honey&lt=commercial', verify=False
     )
     parsed = json.loads(response.text)
     for result in parsed['results']:
@@ -197,7 +197,7 @@ def test_single_license_type_filtering():
 
 
 def test_specific_license_filter():
-    response = requests.get(API_URL + '/image/search?q=honey&li=by', verify=False)
+    response = requests.get(f'{API_URL}/image/search?q=honey&li=by', verify=False)
     parsed = json.loads(response.text)
     for result in parsed['results']:
         assert result['license'] == 'by'
@@ -210,13 +210,13 @@ def test_creator_quotation_grouping():
     """
     no_quotes = json.loads(
         requests.get(
-            API_URL + '/image/search?creator=claude%20monet',
+            f'{API_URL}/image/search?creator=claude%20monet',
             verify=False
         ).text
     )
     quotes = json.loads(
         requests.get(
-            API_URL + '/image/search?creator="claude%20monet"',
+            f'{API_URL}/image/search?creator="claude%20monet"',
             verify=False
         ).text
     )
@@ -231,12 +231,12 @@ def test_creator_quotation_grouping():
 @pytest.fixture
 def test_oauth2_registration():
     payload = {
-        'name': 'INTEGRATION TEST APPLICATION {}'.format(uuid.uuid4()),
+        'name': f'INTEGRATION TEST APPLICATION {uuid.uuid4()}',
         'description': 'A key for testing the OAuth2 registration process.',
         'email': 'example@example.org'
     }
     response = requests.post(
-        API_URL + '/oauth2/register', json=payload, verify=False
+        f'{API_URL}/oauth2/register', json=payload, verify=False
     )
     parsed_response = json.loads(response.text)
     assert response.status_code == 201
@@ -246,16 +246,16 @@ def test_oauth2_registration():
 def test_oauth2_token_exchange(test_oauth2_registration):
     client_id = test_oauth2_registration['client_id']
     client_secret = test_oauth2_registration['client_secret']
-    token_exchange_request = \
-        'client_id={_id}&client_secret={secret}&grant_type=client_credentials' \
-        .format(_id=client_id, secret=client_secret)
+    token_exchange_request = f'client_id={client_id}' \
+                             f'&client_secret={client_secret}' \
+                             f'&grant_type=client_credentials'
     headers = {
         'content-type': "application/x-www-form-urlencoded",
         'cache-control': "no-cache",
     }
     response = json.loads(
         requests.post(
-            API_URL + '/oauth2/token/',
+            f'{API_URL}/oauth2/token/',
             data=token_exchange_request,
             headers=headers,
             verify=False
@@ -336,7 +336,7 @@ def test_attribution():
 
 
 def test_browse_by_provider():
-    response = requests.get(API_URL + '/image/browse/behance',
+    response = requests.get(f'{API_URL}/image/browse/behance',
                             verify=False)
     assert response.status_code == 200
     parsed = json.loads(response.text)
@@ -344,7 +344,7 @@ def test_browse_by_provider():
 
 
 def test_extension_filter():
-    response = requests.get(API_URL + '/image/search?q=honey&extension=jpg')
+    response = requests.get(f'{API_URL}/image/search?q=honey&extension=jpg')
     parsed = json.loads(response.text)
     for result in parsed['results']:
         assert '.jpg' in result['url']
@@ -357,7 +357,7 @@ def search_factory():
     """
     def _parameterized_search(**kwargs):
         response = requests.get(
-            API_URL + '/image/search',
+            f'{API_URL}/image/search',
             params=kwargs,
             verify=False
         )
@@ -458,7 +458,7 @@ def related_factory():
     """
     def _parameterized_search(identifier, **kwargs):
         response = requests.get(
-            API_URL + f'/image/related/{identifier}',
+            f'{API_URL}/image/related/{identifier}',
             params=kwargs,
             verify=False
         )

--- a/openverse-api/test/api_live_search_qa.py
+++ b/openverse-api/test/api_live_search_qa.py
@@ -30,7 +30,7 @@ def test_phrase_relevance():
     """
     search_term = 'home office'
     response = requests.get(
-        API_URL + '/image/search?q={}'.format(search_term),
+        f'{API_URL}/image/search?q={search_term}',
         verify=False
     )
     assert response.status_code == 200

--- a/openverse-api/test/search_qa_test.py
+++ b/openverse-api/test/search_qa_test.py
@@ -19,8 +19,7 @@ class QAScores(Enum):
 @pytest.mark.skip(reason="This test is nondeterministic")
 def test_phrase_relevance():
     res = requests.get(
-        "{}/image/search?q=home office&filter_dead=false&qa=true"
-        .format(API_URL)
+        f"{API_URL}/image/search?q=home office&filter_dead=false&qa=true"
     )
     parsed = json.loads(res.text)
     pprint.pprint(parsed)

--- a/openverse-api/test/v1_integration_test.py
+++ b/openverse-api/test/v1_integration_test.py
@@ -6,7 +6,6 @@ import uuid
 import time
 import catalog.settings
 import xml.etree.ElementTree as ET
-import pprint
 from django.db.models import Max
 from django.urls import reverse
 from catalog.api.licenses import LICENSE_GROUPS
@@ -29,13 +28,13 @@ known_apis = {
 def setup_module():
     if API_URL in known_apis:
         print(
-            '\n\033[1;31;40mTesting {} environment'.format(known_apis[API_URL])
+            f'\n\033[1;31;40mTesting {known_apis[API_URL]} environment'
         )
 
 
 @pytest.fixture
 def search_fixture():
-    response = requests.get(API_URL + '/v1/images?q=dog',
+    response = requests.get(f'{API_URL}/v1/images?q=dog',
                             verify=False)
     assert response.status_code == 200
     parsed = json.loads(response.text)
@@ -46,12 +45,12 @@ def test_search_quotes():
     """
     We want to return a response even if the user messes up quote matching.
     """
-    response = requests.get(API_URL + '/v1/images?q="test', verify=False)
+    response = requests.get(f'{API_URL}/v1/images?q="test', verify=False)
     assert response.status_code == 200
 
 
 def test_search_with_special_characters():
-    response = requests.get(API_URL + '/v1/images?q=dog!', verify=False)
+    response = requests.get(f'{API_URL}/v1/images?q=dog!', verify=False)
     assert response.status_code == 200
 
 
@@ -68,7 +67,7 @@ def test_search_consistency():
     """
     n_pages = 5
     searches = set(
-        requests.get(API_URL + '/v1/images?q=dog;page={}'.format(page),
+        requests.get(f'{API_URL}/v1/images?q=dog;page={page}',
                      verify=False)
         for page in range(1, n_pages)
     )
@@ -84,7 +83,7 @@ def test_search_consistency():
 
 def test_image_detail(search_fixture):
     test_id = search_fixture['results'][0]['id']
-    response = requests.get(API_URL + '/v1/images/{}'.format(test_id), verify=False)
+    response = requests.get(f'{API_URL}/v1/images/{test_id}', verify=False)
     assert response.status_code == 200
 
 
@@ -100,7 +99,7 @@ def test_image_thumb(search_fixture):
 def link_shortener_fixture(search_fixture):
     link_to_shorten = search_fixture['results'][0]['detail_url']
     payload = {"full_url": link_to_shorten}
-    response = requests.post(API_URL + '/v1/link', json=payload, verify=False)
+    response = requests.post(f'{API_URL}/v1/link', json=payload, verify=False)
     assert response.status_code == 200
     return json.loads(response.text)
 
@@ -111,13 +110,13 @@ def test_link_shortener_create(link_shortener_fixture):
 
 def test_link_shortener_resolve(link_shortener_fixture):
     path = link_shortener_fixture['shortened_url'].split('/')[-1]
-    response = requests.get(API_URL + '/v1/link/' + path, allow_redirects=False,
+    response = requests.get(f'{API_URL}/v1/link/{path}', allow_redirects=False,
                             verify=False)
     assert response.status_code == 301
 
 
 def test_stats():
-    response = requests.get(API_URL + '/v1/sources?type=images', verify=False)
+    response = requests.get(f'{API_URL}/v1/sources?type=images', verify=False)
     parsed_response = json.loads(response.text)
     assert response.status_code == 200
     num_images = 0
@@ -137,7 +136,7 @@ def test_list_create(search_fixture):
         'title': 'INTEGRATION TEST',
         'images': [search_fixture['results'][0]['id']]
     }
-    response = requests.post(API_URL + '/list', json=payload, verify=False)
+    response = requests.post(f'{API_URL}/list', json=payload, verify=False)
     parsed_response = json.loads(response.text)
     assert response.status_code == 201
     return parsed_response
@@ -147,7 +146,7 @@ def test_list_create(search_fixture):
 def test_list_detail(test_list_create):
     list_slug = test_list_create['url'].split('/')[-1]
     response = requests.get(
-        API_URL + '/list/{}'.format(list_slug), verify=False
+        f'{API_URL}/list/{list_slug}', verify=False
     )
     assert response.status_code == 200
 
@@ -156,9 +155,9 @@ def test_list_detail(test_list_create):
 def test_list_delete(test_list_create):
     list_slug = test_list_create['url'].split('/')[-1]
     token = test_list_create['auth']
-    headers = {"Authorization": "Token {}".format(token)}
+    headers = {"Authorization": f"Token {token}"}
     response = requests.delete(
-        API_URL + '/list/{}'.format(list_slug),
+        f'{API_URL}/list/{list_slug}',
         headers=headers,
         verify=False
     )
@@ -173,7 +172,7 @@ def test_license_type_filtering():
     modification = LICENSE_GROUPS['modification']
     commercial_and_modification = set.intersection(modification, commercial)
     response = requests.get(
-        API_URL + '/v1/images?q=dog&license_type=commercial,modification',
+        f'{API_URL}/v1/images?q=dog&license_type=commercial,modification',
         verify=False
     )
     parsed = json.loads(response.text)
@@ -184,7 +183,7 @@ def test_license_type_filtering():
 def test_single_license_type_filtering():
     commercial = LICENSE_GROUPS['commercial']
     response = requests.get(
-        API_URL + '/v1/images?q=dog&license_type=commercial', verify=False
+        f'{API_URL}/v1/images?q=dog&license_type=commercial', verify=False
     )
     parsed = json.loads(response.text)
     for result in parsed['results']:
@@ -193,7 +192,7 @@ def test_single_license_type_filtering():
 
 def test_specific_license_filter():
     response = requests.get(
-        API_URL + '/v1/images?q=dog&license=by', verify=False
+        f'{API_URL}/v1/images?q=dog&license=by', verify=False
     )
     parsed = json.loads(response.text)
     for result in parsed['results']:
@@ -207,13 +206,13 @@ def test_creator_quotation_grouping():
     """
     no_quotes = json.loads(
         requests.get(
-            API_URL + '/v1/images?creator=claude%20monet',
+            f'{API_URL}/v1/images?creator=claude%20monet',
             verify=False
         ).text
     )
     quotes = json.loads(
         requests.get(
-            API_URL + '/v1/images?creator="claude%20monet"',
+            f'{API_URL}/v1/images?creator="claude%20monet"',
             verify=False
         ).text
     )
@@ -228,12 +227,12 @@ def test_creator_quotation_grouping():
 @pytest.fixture
 def test_auth_tokens_registration():
     payload = {
-        'name': 'INTEGRATION TEST APPLICATION {}'.format(uuid.uuid4()),
+        'name': f'INTEGRATION TEST APPLICATION {uuid.uuid4()}',
         'description': 'A key for testing the OAuth2 registration process.',
         'email': 'example@example.org'
     }
     response = requests.post(
-        API_URL + '/v1/auth_tokens/register', json=payload, verify=False
+        f'{API_URL}/v1/auth_tokens/register', json=payload, verify=False
     )
     parsed_response = json.loads(response.text)
     assert response.status_code == 201
@@ -244,16 +243,16 @@ def test_auth_tokens_registration():
 def test_auth_token_exchange(test_auth_tokens_registration):
     client_id = test_auth_tokens_registration['client_id']
     client_secret = test_auth_tokens_registration['client_secret']
-    token_exchange_request = \
-        'client_id={_id}&client_secret={secret}&grant_type=client_credentials' \
-        .format(_id=client_id, secret=client_secret)
+    token_exchange_request = f'client_id={client_id}&'\
+                             f'client_secret={client_secret}&'\
+                             'grant_type=client_credentials'
     headers = {
         'content-type': "application/x-www-form-urlencoded",
         'cache-control': "no-cache",
     }
     response = json.loads(
         requests.post(
-            API_URL + '/v1/auth_tokens/token/',
+            f'{API_URL}/v1/auth_tokens/token/',
             data=token_exchange_request,
             headers=headers,
             verify=False
@@ -297,19 +296,19 @@ def django_db_setup():
 
 @pytest.mark.django_db
 def test_auth_email_verification(test_auth_token_exchange, django_db_setup):
-        # This test needs to cheat by looking in the database, so it will be
-        # skipped in non-local environments.
-        if API_URL == 'http://localhost:8000':
-            _id = OAuth2Verification.objects.aggregate(Max('id'))['id__max']
-            verify = OAuth2Verification.objects.get(id=_id)
-            code = verify.code
-            path = reverse('verify-email', args=[code])
-            url = f'{API_URL}{path}'
-            response = requests.get(url)
-            assert response.status_code == 200
-            test_auth_rate_limit_reporting(
-                test_auth_token_exchange, verified=True
-            )
+    # This test needs to cheat by looking in the database, so it will be
+    # skipped in non-local environments.
+    if API_URL == 'http://localhost:8000':
+        _id = OAuth2Verification.objects.aggregate(Max('id'))['id__max']
+        verify = OAuth2Verification.objects.get(id=_id)
+        code = verify.code
+        path = reverse('verify-email', args=[code])
+        url = f'{API_URL}{path}'
+        response = requests.get(url)
+        assert response.status_code == 200
+        test_auth_rate_limit_reporting(
+            test_auth_token_exchange, verified=True
+        )
 
 
 @pytest.mark.skip(reason="Unmaintained feature/grequests ssl recursion bug")
@@ -378,6 +377,7 @@ def test_attribution():
     assert title in all_data_present.attribution
     assert creator in all_data_present.attribution
 
+
 def test_license_override():
     null_license_url = Image(
         identifier="ab80dbe1-414c-4ee8-9543-f9599312aeb8",
@@ -389,9 +389,10 @@ def test_license_override():
     )
     assert null_license_url.license_url is not None
 
+
 def test_source_search():
     response = requests.get(
-        API_URL + '/v1/images?source=behance', verify=False
+        f'{API_URL}/v1/images?source=behance', verify=False
     )
     if response.status_code != 200:
         print(f'Request failed. Message: {response.body}')
@@ -401,7 +402,7 @@ def test_source_search():
 
 
 def test_extension_filter():
-    response = requests.get(API_URL + '/v1/images?q=dog&extension=jpg')
+    response = requests.get(f'{API_URL}/v1/images?q=dog&extension=jpg')
     parsed = json.loads(response.text)
     for result in parsed['results']:
         assert '.jpg' in result['url']
@@ -412,9 +413,10 @@ def search_factory():
     """
     Allows passing url parameters along with a search request.
     """
+
     def _parameterized_search(**kwargs):
         response = requests.get(
-            API_URL + '/v1/images',
+            f'{API_URL}/v1/images',
             params=kwargs,
             verify=False
         )
@@ -513,21 +515,25 @@ def recommendation_factory():
     """
     Allows passing url parameters along with a related images request.
     """
+
     def _parameterized_search(identifier, **kwargs):
         response = requests.get(
-            API_URL + f'/v1/recommendations?type=images&id={identifier}',
+            f'{API_URL}/v1/recommendations?type=images&id={identifier}',
             params=kwargs,
             verify=False
         )
         assert response.status_code == 200
         parsed = response.json()
         return parsed
+
     return _parameterized_search
 
 
 @pytest.mark.skip(reason="Generally, we don't paginate related images, so "
-                    "consistency is less of an issue.")
-def test_related_image_search_page_consistency(recommendation, search_without_dead_links):
+                         "consistency is less of an issue.")
+def test_related_image_search_page_consistency(
+        recommendation, search_without_dead_links
+):
     initial_images = search_without_dead_links(q='*', page_size=10)
     for image in initial_images['results']:
         related = recommendation_factory(image['id'])
@@ -537,7 +543,8 @@ def test_related_image_search_page_consistency(recommendation, search_without_de
 
 def test_oembed_endpoint_for_json():
     response = requests.get(
-        API_URL + '/v1/oembed?url=https%3A//search.creativecommons.org/photos/dac5f6b0-e07a-44a0-a444-7f43d71f9beb'
+        f'{API_URL}/v1/oembed?url=https%3A//'
+        'search.creativecommons.org/photos/dac5f6b0-e07a-44a0-a444-7f43d71f9beb'
     )
     assert response.status_code == 200
     assert response.headers['Content-Type'] == "application/json"
@@ -549,7 +556,9 @@ def test_oembed_endpoint_for_json():
 
 def test_oembed_endpoint_for_xml():
     response = requests.get(
-        API_URL + '/v1/oembed?url=https%3A//search.creativecommons.org/photos/dac5f6b0-e07a-44a0-a444-7f43d71f9beb&format=xml'
+        f'{API_URL}/v1/oembed?url=https%3A//'
+        'search.creativecommons.org/photos/'
+        'dac5f6b0-e07a-44a0-a444-7f43d71f9beb&format=xml'
     )
     assert response.status_code == 200
     assert response.headers['Content-Type'] == "application/xml; charset=utf-8"
@@ -566,6 +575,8 @@ def test_report_endpoint():
         'identifier': identifier,
         'reason': 'mature'
     }
-    response = requests.post(API_URL + '/v1/images/{}/report'.format(identifier), json=payload, verify=False)
+    response = requests.post(
+        f'{API_URL}/v1/images/{identifier}/report',
+        json=payload, verify=False)
     assert response.status_code == 201
     return json.loads(response.text)


### PR DESCRIPTION
Python 3.6 introduced a new way of formatting strings using so-called f-strings. This made formatted strings more readable and concize.

Instead of writing 
```python
who = "world"
print("Hello {who}".format(who=who))
```

we can write 

```python
who = "world"
print(f"Hello {who}")
```

This PR consistently replaces `string.format` with `f-strings`.

Signed-off-by: Olga Bulat <obulat@gmail.com>