### PR TITLE
Update Docker image for ingestion-server to use bind mounts properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,7 @@ ccbot/crawl_plan.yml
 .DS_Store
 *.iml
 .idea
+
+# Ingestion server
+ingestion_server/ingestion_server/db
+ingestion_server/ingestion_server/lock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
       - es
       - indexer-worker
     volumes:
-      - ./ingestion_server:/ingestion-server
+      - ./ingestion_server:/ingestion_server
     environment:
       PYTHONUNBUFFERED: "0"
       ELASTICSEARCH_URL: 'es'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,6 +114,8 @@ services:
       DB_BUFFER_SIZE: '100000'
       COPY_TABLES: 'image'
       SYNCER_POLL_INTERVAL: '60'
+      LOCK_PATH: /worker_state/lock
+      SHELF_PATH: /worker_state/db
     stdin_open: true
     tty: true
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,7 +129,7 @@ services:
       - db
       - es
     volumes:
-      - ./ingestion_server:/ingestion-server
+      - ./ingestion_server:/ingestion_server
     environment:
       PYTHONUNBUFFERED: "0"
       ELASTICSEARCH_URL: 'es'
@@ -144,6 +144,8 @@ services:
       DB_BUFFER_SIZE: '100000'
       COPY_TABLES: 'image'
       SYNCER_POLL_INTERVAL: '60'
+      LOCK_PATH: /worker_state/lock
+      SHELF_PATH: /worker_state/db
     stdin_open: true
     tty: true
 

--- a/ingestion_server/Dockerfile
+++ b/ingestion_server/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update \
     && mkdir -p /var/log/supervisord/ \
     && chown -R supervisord:supervisord /var/log/supervisord \
     && mkdir /ingestion_server \
-    && chown -R supervisord:supervisord /ingestion_server
+    && mkdir /worker_state \
+    && chown -R supervisord:supervisord /worker_state
 
 ENV PYTHONPATH=$PYTHONPATH:/ingestion_server/
 

--- a/ingestion_server/Dockerfile
+++ b/ingestion_server/Dockerfile
@@ -2,27 +2,33 @@ FROM python:3.9
 
 ENV PYTHONBUFFERED 1
 
-RUN groupadd --system supervisord && useradd --system --gid supervisord supervisord
+RUN groupadd --system supervisord \
+    && useradd --system --gid supervisord supervisord
 
 RUN apt-get update \
     && apt-get install -y supervisor \
     && mkdir -p /var/log/supervisord/ \
-    && chown -R supervisord:supervisord /var/log/supervisord
+    && chown -R supervisord:supervisord /var/log/supervisord \
+    && mkdir /ingestion_server
+
+ENV PYTHONPATH=$PYTHONPATH:/ingestion_server/
+
+WORKDIR /ingestion_server
 
 # Install Python dependency management tools
 RUN pip install --upgrade pip \
     && pip install --upgrade setuptools \
     && pip install --upgrade pipenv
 
-# Copy all files into the container
-COPY . /ingestion_server/
-WORKDIR /ingestion_server
-RUN chown -R supervisord:supervisord /ingestion_server
-ENV PYTHONPATH=$PYTHONPATH:/ingestion_server/
+# Copy the Pipenv files into the container
+COPY Pipfile /ingestion_server/
+COPY Pipfile.lock /ingestion_server/
 
 # Install the dependencies system-wide
 # TODO: Use build args to avoid installing dev dependencies in production
 RUN pipenv install --deploy --system --dev
+
 USER supervisord
 EXPOSE 8001
+
 CMD ["supervisord", "-c", "/ingestion_server/config/supervisord.conf"]

--- a/ingestion_server/Dockerfile
+++ b/ingestion_server/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update \
     && apt-get install -y supervisor \
     && mkdir -p /var/log/supervisord/ \
     && chown -R supervisord:supervisord /var/log/supervisord \
-    && mkdir /ingestion_server
+    && mkdir /ingestion_server \
+    && chown -R supervisord:supervisord /ingestion_server
 
 ENV PYTHONPATH=$PYTHONPATH:/ingestion_server/
 

--- a/ingestion_server/Dockerfile-worker
+++ b/ingestion_server/Dockerfile-worker
@@ -2,16 +2,26 @@ FROM python:3.9
 
 ENV PYTHONBUFFERED 1
 
+RUN mkdir /ingestion_server \
+    && mkdir /worker_state
+
+ENV PYTHONPATH=$PYTHONPATH:/ingestion_server/
+
+WORKDIR /ingestion_server
+
 # Install Python dependency management tools
 RUN pip install --upgrade pip \
     && pip install --upgrade setuptools \
     && pip install --upgrade pipenv
 
-# Copy all files into the container
-COPY . /ingestion_server/
-WORKDIR /ingestion_server
-ENV PYTHONPATH=$PYTHONPATH:/ingestion_server/
+# Copy the Pipenv files into the container
+COPY Pipfile /ingestion_server/
+COPY Pipfile.lock /ingestion_server/
 
+# Install the dependencies system-wide
+# TODO: Use build args to avoid installing dev dependencies in production
 RUN pipenv install --deploy --system --dev
+
 EXPOSE 8002
+
 CMD gunicorn indexer_worker:api -b 0.0.0.0:8002 --reload --access-logfile '-' --error-logfile '-' --chdir ./ingestion_server/


### PR DESCRIPTION
This PR updates the ingestion server `Dockerfile` and the project `docker-compose.yml` file to bind-mount the ingestion-server codebase from the repository instead of copying the code during image build. This allows code changes to reflect immediately in the container instead of needing a rebuild everytime.

As a side-effect, two binary files named `db` and `lock` get created in the repo which should not be Git tracked so they have been `.gitignore`-d.

Also this PR makes the `Dockerfile` symmetrical with the API `Dockerfile`, which is good.