### PR TITLE
Suppress warning about blank env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,8 +79,8 @@ services:
       - ROOT_SHORTENING_URL=localhost:8000
       - THUMBNAIL_PROXY_URL=http://thumbs:8222
       - DJANGO_SECRET_KEY=ny#b__$$f6ry4wy8oxre97&-68u_0lk3gw(z=d40_dxey3zw0v1
-      - AWS_SECRET_ACCESS_KEY
-      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY=''
+      - AWS_ACCESS_KEY_ID=''
     stdin_open: true
     tty: true
 


### PR DESCRIPTION
Docker v3.5.2 (66501) with Compose v1.29.2 raises warnings about empty environment variables. 
```
WARN[0000] The AWS_ACCESS_KEY_ID variable is not set. Defaulting to a blank string. 
WARN[0000] The AWS_SECRET_ACCESS_KEY variable is not set. Defaulting to a blank string. 
```

This PR suppresses those warnings by explicitly setting the blank strings.