### PR TITLE
Modify docker-compose file for Ingestion-server's integration tests

### DIFF
--- a/ingestion_server/test/generate_integration_test_docker_compose.py
+++ b/ingestion_server/test/generate_integration_test_docker_compose.py
@@ -31,6 +31,7 @@ with open(parent_docker_compose, 'r') as docker_compose_file:
         es = docker_compose['services']['es']
         ingestion_server = docker_compose['services']['ingestion-server']
         upstream_db = docker_compose['services']['upstream_db']
+
         # Delete services we're not testing.
         desired_services = {'es', 'db', 'ingestion-server', 'upstream_db'}
         for service in dict(docker_compose['services']):
@@ -55,6 +56,9 @@ with open(parent_docker_compose, 'r') as docker_compose_file:
         ingestion_server['depends_on'] = ['integration-es', 'integration-db']
         ingestion_server['build'] = '../'
 
+        # Set the directory correctly in the volume
+        ingestion_server['volumes'] = ['../:/ingestion_server']
+
         # Create a volume for the mock data
         db['volumes'] = ['./mock_data:/mock_data']
         upstream_db['volumes'] = ['./mock_data:/mock_data']
@@ -67,7 +71,6 @@ with open(parent_docker_compose, 'r') as docker_compose_file:
         docker_compose['services']['integration-es'] = es
         docker_compose['services']['integration-ingestion'] = ingestion_server
         docker_compose['services']['integration-upstream'] = upstream_db
-
 
         # Start the document with a warning message
         warning_message = '\n'.join(textwrap.wrap(

--- a/ingestion_server/test/integration-test-docker-compose.yml
+++ b/ingestion_server/test/integration-test-docker-compose.yml
@@ -1,7 +1,7 @@
-# This docker-compose file was generated from /home/alden/code/cccatalog-
+# This docker-compose file was generated from /Users/krysal/codes/openverse-
 # api/ingestion_server/test/../../docker-compose.yml. Do not modify this file
-# directly. Your changes will be overwritten. Last update: 2019-01-09
-# 11:36:00.858884
+# directly. Your changes will be overwritten. Last update: 2021-07-14
+# 20:27:30.193024
 
 services:
   integration-db:
@@ -12,7 +12,7 @@ services:
       POSTGRES_USER: deploy
     healthcheck:
       test: pg_isready -U deploy -d openledger
-    image: postgres:10.3-alpine
+    image: postgres:13.2-alpine
     ports:
     - 60000:5432
     volumes:
@@ -20,6 +20,7 @@ services:
   integration-es:
     environment:
     - xpack.security.enabled=false
+    - discovery.type=single-node
     image: docker.elastic.co/elasticsearch/elasticsearch:7.12.0
     ports:
     - 60001:9200
@@ -43,7 +44,9 @@ services:
       DB_BUFFER_SIZE: '100000'
       ELASTICSEARCH_PORT: '9200'
       ELASTICSEARCH_URL: integration-es
+      LOCK_PATH: /worker_state/lock
       PYTHONUNBUFFERED: '0'
+      SHELF_PATH: /worker_state/db
       SYNCER_POLL_INTERVAL: '60'
       UPSTREAM_DB_HOST: integration-upstream
       UPSTREAM_DB_PORT: 5432
@@ -52,7 +55,7 @@ services:
     stdin_open: true
     tty: true
     volumes:
-    - ./ingestion_server:/ingestion-server
+    - ../:/ingestion_server
   integration-upstream:
     environment:
       POSTGRES_DB: openledger
@@ -61,7 +64,7 @@ services:
       POSTGRES_USER: deploy
     healthcheck:
       test: pg_isready -U deploy -d openledger
-    image: postgres:10.3-alpine
+    image: postgres:13.2-alpine
     ports:
     - 59999:5432
     volumes:

--- a/ingestion_server/test/integration_tests.py
+++ b/ingestion_server/test/integration_tests.py
@@ -102,7 +102,6 @@ class TestIngestion(unittest.TestCase):
                 res_json = es_res.json()
                 if res_json['status'] not in ready_stats:
                     continue
-                attempts += 1
             except requests.exceptions.ConnectionError:
                 if attempts > max_attempts:
                     logging.error('Ingestion server timed out. Giving up.')
@@ -110,6 +109,8 @@ class TestIngestion(unittest.TestCase):
                 logging.info('Waiting for ingestion server to come up...')
                 time.sleep(5)
                 continue
+            finally:
+                attempts += 1
             logging.info('Successfully connected to ingestion server')
             break
 


### PR DESCRIPTION
Related to #143 and #104.

When executing integration tests (steps in [README][readme_ref] file) of the ingestion-server, the **integration-ingestion** service cannot start correctly due to source files not being mounted in the docker container. The error in the logs appeared as:
```
INFO:root:Waiting for ingestion server to come up...
integration-ingestion_1  | Error: could not find config file config/supervisord.conf
integration-ingestion_1  | For help, use /usr/bin/supervisord -h
test_integration-ingestion_1 exited with code 2
INFO:root:Waiting for ingestion server to come up...
INFO:root:Waiting for ingestion server to come up...
INFO:root:Waiting for ingestion server to come up...
INFO:root:Waiting for ingestion server to come up...
INFO:root:Waiting for ingestion server to come up...
INFO:root:Waiting for ingestion server to come up...
ERROR:root:Ingestion server timed out. Giving up.
```

This PR fixes the generation of the docker-compose file for ingestion-server's tests. Also moves the increment of the `attempts` variable to the `finally` block of the exception, in order to prevent an infinite loop, previously it wasn't incrementing if the `except` block was executed.

This does not fix the integration tests completely but enables them to run, a first step.

[readme_ref]: https://github.com/WordPress/openverse-api/blob/dc_integration_tests/README.md#how-to-run-ingestion-server-tests