### PR TITLE
Add the `sound_effect` category

### DIFF
--- a/openverse-api/catalog/api/migrations/0032_audio_models.py
+++ b/openverse-api/catalog/api/migrations/0032_audio_models.py
@@ -40,7 +40,7 @@ class Migration(migrations.Migration):
                 ('meta_data', django.contrib.postgres.fields.jsonb.JSONField(blank=True, null=True)),
                 ('audio_set_position', models.IntegerField(blank=True, help_text='Ordering of the audio in the set.', null=True)),
                 ('genres', django.contrib.postgres.fields.ArrayField(base_field=models.CharField(blank=True, max_length=80), db_index=True, help_text='The artistic style of this audio file, eg. hip-hop (music) / tech (podcasts).', null=True, size=None)),
-                ('category', models.CharField(blank=True, db_index=True, help_text='The category of this audio file, eg. music, podcast, news & audiobook.', max_length=80, null=True)),
+                ('category', models.CharField(blank=True, db_index=True, help_text='The category of this audio file, eg. music, sound_effect, podcast, news & audiobook.', max_length=80, null=True)),
                 ('duration', models.IntegerField(blank=True, help_text='The time length of the audio file in milliseconds.', null=True)),
                 ('bit_rate', models.IntegerField(blank=True, help_text='Number in bits per second, eg. 128000.', null=True)),
                 ('sample_rate', models.IntegerField(blank=True, help_text='Number in hertz, eg. 44100.', null=True)),

--- a/openverse-api/catalog/api/models/audio.py
+++ b/openverse-api/catalog/api/models/audio.py
@@ -84,7 +84,7 @@ class Audio(AbstractMedia):
         null=True,
         db_index=True,
         help_text='The category of this audio file, '
-                  'eg. music, podcast, news & audiobook.',
+                  'eg. music, sound_effect, podcast, news & audiobook.',
     )
 
     duration = models.IntegerField(

--- a/openverse-api/catalog/api/serializers/audio_serializers.py
+++ b/openverse-api/catalog/api/serializers/audio_serializers.py
@@ -35,7 +35,8 @@ class AudioSearchQueryStringSerializer(MediaSearchQueryStringSerializer):
     categories = serializers.CharField(
         label="categories",
         help_text="A comma separated list of categories; available categories "
-                  "include `music`, `podcast`, `audiobook`, and `news`.",
+                  "include `music`, `sound_effect`, `podcast`, `audiobook`, "
+                  "and `news`.",
         required=False
     )
     duration = serializers.CharField(
@@ -57,6 +58,7 @@ class AudioSearchQueryStringSerializer(MediaSearchQueryStringSerializer):
     def validate_categories(value):
         valid_categories = {
             'music',
+            'sound_effect',
             'podcast',
             'news',
             'audiobook',


### PR DESCRIPTION
This PR adds the 'sound_effect' category in the model, migration and serializer. The migration `0032_audio_models.py` has been modified instead of creating a new one because the change hasn't gone into production.