### PR TITLE
Add just recipe to wait for stack startup

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -28,6 +28,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v1
+    - uses: extractions/setup-just@v1
     - name: Install dependencies
       run: |
         pip install pytest pipenv
@@ -38,12 +39,8 @@ jobs:
     - name: Cache Docker images
       uses: satackey/action-docker-layer-caching@v0.0.11
       continue-on-error: true
-    - name: Start API
-      run: docker-compose up --build -d
-    - name: Wait for API to come up
-      run: bash -c 'while [[ "$(curl --insecure -s -o /dev/null -w ''%{http_code}'' http://localhost:8000/healthcheck)" != "200" ]]; do sleep 10; done'
-    - name: Ingest and index test data
-      run: ./load_sample_data.sh
+    - name: Start API, ingest and index test data
+      run: just init
     - name: Wait for data to be indexed in Elasticsearch
       run: bash -c 'while [[ "$(curl -sb -H "Accept:application/json" http://localhost:9200/_cat/aliases/image | grep -c image-)" == "0" || "$(curl -sb -H "Accept:application/json" http://localhost:9200/_cat/aliases/audio | grep -c audio-)" == "0" ]]; do sleep 5 && docker-compose logs; done'
     - name: Run API tests

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ es-venv
 # IDE junk
 .idea
 
+# Vim junk
+*.swp
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,10 @@ services:
       nofile:
         soft: 65536
         hard: 65536
+    # Memory limit for ES, as it tends to be a memory hoarder
+    # Set this value to an empty string to remove the limit
+    # https://docs.docker.com/compose/compose-file/compose-file-v2/#cpu-and-other-resources
+    mem_limit: ${ES_MEM_LIMIT:-4g}
 
   web:
     build: openverse_api/

--- a/justfile
+++ b/justfile
@@ -33,8 +33,12 @@ env:
     cp openverse_api/env.template openverse_api/.env
     cp ingestion_server/env.template ingestion_server/.env
 
+# Wait until services are healthy
+wait-until-healthy: up
+    @bash -c 'while [[ "$(curl --insecure -s -o /dev/null -w ''%{http_code}'' http://localhost:8000/healthcheck)" != "200" ]]; do echo "Waiting for services to start up... " && sleep 10; done'
+
 # Load sample data into the Docker Compose services
-init: up
+init: wait-until-healthy
     ./load_sample_data.sh
 
 # Make a test cURL request to the API
@@ -65,7 +69,7 @@ lint:
 #######
 
 # Run API tests inside Docker
-test: up
+test: wait-until-healthy
     docker-compose exec web ./test/run_test.sh
 
 # Run API tests locally


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #259 by @dhruvkb

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds a new `just` recipe, `wait-until-healthy`, which waits for the services to complete their healthchecks before finishing. This recipe is then a dependent for all other recipes that require the services to be up prior to running.

I've also modified the integration test GHA so it uses the `just init` recipe rather than the 3 separate steps. If we'd prefer to have more granularity in steps there, I'm happy to revert that.

When I launched the stack on my machine, all of my memory was immediately allocated. Elasticsearch ended up taking **16 GB** of RAM :scream:. I added a limit to the `docker-compose.yml` of 4GB, which I believe should be sufficient for ES. It can be overridden with the `ES_MEM_LIMIT` environment variable, including removing the limit entirely with `ES_MEM_LIMIT=''`. Since this is devex specific, I think it should ultimately go into the `docker-compose-override.yml` file that we have similar to the catalog repo.

Lastly I added Vim's `.swp` files to the `.gitignore`.

<details><summary>Sample `just init` output</summary>

Note the `Waiting for services to start up...` lines.

```
$ just init
docker-compose -f docker-compose.yml up -d
Creating network "openverse-api_default" with the default driver
Creating openverse-api_thumbs_1         ... done
Creating openverse-api_cache_1       ... done
Creating openverse-api_analytics_1      ... done
Creating openverse-api_db_1          ... done
Creating openverse-api_es_1          ... done
Creating openverse-api_upstream_db_1    ... done
Creating openverse-api_indexer-worker_1 ... done
Creating openverse-api_web_1            ... done
Creating openverse-api_ingestion-server_1 ... done
Waiting for services to start up... 
Waiting for services to start up... 
./load_sample_data.sh
/usr/local/lib/python3.9/site-packages/grequests.py:22: MonkeyPatchWarning: Patching more than once will result in the union of all True parameters being patched
  curious_george.patch_all(thread=False, select=False)
GET http://es:9200/ [status:200 request:0.005s]
GET http://es:9200/ [status:200 request:0.003s]
Operations to perform:
  Apply all migrations: admin, api, auth, contenttypes, oauth2_provider, sessions
Running migrations:
  Applying contenttypes.0001_initial... OK
  Applying auth.0001_initial... OK
  Applying admin.0001_initial... OK
  Applying admin.0002_logentry_remove_auto_add... OK
  Applying admin.0003_logentry_add_action_flag_choices... OK
  Applying api.0001_initial... OK
  Applying api.0002_auto_20180723_1737... OK
  Applying api.0003_image_view_count... OK
  Applying api.0004_shortenedlink... OK
  Applying api.0005_auto_20180803_1905... OK
  Applying api.0006_image_watermarked... OK
  Applying api.0007_auto_20180803_1909... OK
  Applying api.0008_imagelist_slug... OK
  Applying api.0009_auto_20180831_1425... OK
  Applying api.0010_auto_20180831_1815... OK
  Applying api.0011_auto_20181117_0029... OK
  Applying api.0012_auto_20190102_2012... OK
  Applying api.0013_contentprovider... OK
  Applying api.0014_auto_20190122_1853... OK
```

</details>

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. Run `just down -v`
1. Run `just init`
1. Watch for the `Waiting for services` lines, and observe no failures!

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
