### PR TITLE
Add filesize and filetype to the API endpoints

### DIFF
--- a/openverse_api/catalog/api/examples/audio_responses.py
+++ b/openverse_api/catalog/api/examples/audio_responses.py
@@ -84,6 +84,8 @@ audio_detail_200_example = {
         "bit_rate": None,
         "sample_rate": None,
         "alt_files": None,
+        "filesize": None,
+        "filetype": "mp3",
     },
 }
 

--- a/openverse_api/catalog/api/examples/image_responses.py
+++ b/openverse_api/catalog/api/examples/image_responses.py
@@ -92,6 +92,8 @@ image_detail_200_example = {
         "width": 1276,
         "tags": None,
         "creator_url": None,
+        "filesize": None,
+        "filetype": None,
     }
 }
 

--- a/openverse_api/catalog/api/serializers/media_serializers.py
+++ b/openverse_api/catalog/api/serializers/media_serializers.py
@@ -222,6 +222,8 @@ class MediaSerializer(serializers.Serializer):
         "creator",
         "creator_url",
         "url",
+        "filesize",
+        "filetype",
         "license",
         "license_version",
         "license_url",
@@ -260,6 +262,13 @@ class MediaSerializer(serializers.Serializer):
 
     # Fields corresponding to FileMixin
     url = serializers.URLField(help_text="The actual URL to the media file.")
+    filesize = serializers.CharField(
+        required=False, help_text="Number in bytes, e.g. 1024."
+    )
+    filetype = serializers.CharField(
+        required=False,
+        help_text="The type of the file, related to the file extension.",
+    )
 
     # Fields corresponding to AbstractMedia
     license = serializers.SerializerMethodField(


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR furthers work done in #266 regarding `filetype` and `filesize` fields in the API.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
