### PR TITLE
Modify image search url examples in docs to avoid redirects

### DIFF
--- a/openverse_api/catalog/api/examples/image_requests.py
+++ b/openverse_api/catalog/api/examples/image_requests.py
@@ -23,7 +23,7 @@ syntax_examples = {
 image_search_list_curl = "\n".join(
     f"""
 # Example {index}: Search for images {purpose}
-curl {auth} "{origin}/v1/images?q={syntax}"
+curl {auth} "{origin}/v1/images/?q={syntax}"
 """
     for (index, (purpose, syntax)) in enumerate(syntax_examples.items())
 )


### PR DESCRIPTION
<!-- ## Fixes  -->
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
<!-- Fixes #[issue number] by @[issue author]  -->

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This small PR adds `/` before the query string to the example URLs of the **image_search** endpoint, as the current ones showed require a redirect to get the actual response with data.

So doing `curl "http://localhost:8000/v1/images?q=hummingbird"` gets no response unless you add the `-L` flag to follow redirects. Add `-v` to see more details.

```
*   Trying 127.0.0.1:8000...
* Connected to localhost (127.0.0.1) port 8000 (#0)
> GET /v1/images?q=hummingbird HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/7.78.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 301 Moved Permanently
< Date: Fri, 22 Oct 2021 21:56:19 GMT
< Server: WSGIServer/0.2 CPython/3.10.0
< Content-Type: text/html; charset=utf-8
< Location: /v1/images/?q=hummingbird
< Content-Length: 0
< Vary: Origin
< X-Content-Type-Options: nosniff
< Referrer-Policy: same-origin
< 
* Connection #0 to host localhost left intact
```

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Go to `http://localhost:8000/v1/#tag/images` and test the URLs shown. They should return a response directly.
For example, try:
```
curl "http://localhost:8000/v1/images/?q=hummingbird"
```
and you should see a response similar to:

```json
{"result_count":4,"page_count":0,"page_size":20,"page":1,"results":[{"id":"57aec47d-e795-4698-a0c4-726a803869ee","title":"DSCN 4487ex P900 new visitor","foreign_landing_url":"https://www.flickr.com/photos/25171569@N02/20276419142","creator":"jjjj56cp","creator_url":"https://www.flickr.com/photos/25171569@N02","url":"https://live.staticflickr.com/549/20276419142_3616054f80_b.jpg","license":"by-nc-sa","license_version":"2.0","license_url":"https://creativecommons.org/licenses/by-nc-sa/2.0/","provider":"flickr","source":"flickr","tags":[{"name":"aves"},{"name":"birds"},{"name":"feeder"},{"name":"female"},{"name":"immature"},{"name":"inthewild"},{"name":"jennypansing"},{"name":"p900"},{"name":"profile"},{"name":"sipping"}],"fields_matched":["description"],"thumbnail":"http://localhost:8000/v1/images/57aec47d-e795-4698-a0c4-726a803869ee/thumb/","detail_url":"http://localhost:8000/v1/images/57aec47d-e795-4698-a0c4-726a803869ee/","related_url":"http://localhost:8000/v1/images/57aec47d-e795-4698-a0c4-726a803869ee/related/"},{"id":"6dfe2589-c62c-4813-836b-9cbe69b6cf9d","title":"Bird Feeder Photo","foreign_landing_url":"https://stocksnap.io/photo/bird-feeder-CJCIUUSGNM","creator":"Stephen Rahn","creator_url":"https://stocksnap.io/author/srahn","url":"https://cdn.stocksnap.io/img-thumbs/960w/CJCIUUSGNM.jpg","license":"cc0","license_version":"1.0","license_url":"https://creativecommons.org/publicdomain/zero/1.0/","provider":"stocksnap","source":"stocksnap","tags":[{"name":"animal"},{"name":"beak"},{"name":"bird"},{"name":"colorful"},{"name":"eating"},{"name":"feathers"},{"name":"feeder"},{"name":"flying"},{"name":"food"},{"name":"hummingbird"},{"name":"hungry"},{"name":"nature"},{"name":"seed"},{"name":"small"},{"name":"wildlife"},{"name":"wings"}],"fields_matched":["tags.name"],"thumbnail":"http://localhost:8000/v1/images/6dfe2589-c62c-4813-836b-9cbe69b6cf9d/thumb/","detail_url":"http://localhost:8000/v1/images/6dfe2589-c62c-4813-836b-9cbe69b6cf9d/","related_url":"http://localhost:8000/v1/images/6dfe2589-c62c-4813-836b-9cbe69b6cf9d/related/"},{"id":"6d5cf6cb-f772-46fc-a3d9-99617be7731b","title":"Bird Perched Photo","foreign_landing_url":"https://stocksnap.io/photo/bird-perched-NCIPWMTOW6","creator":"World Wildlife","creator_url":"https://stocksnap.io/author/worldwildlife","url":"https://cdn.stocksnap.io/img-thumbs/960w/NCIPWMTOW6.jpg","license":"cc0","license_version":"1.0","license_url":"https://creativecommons.org/publicdomain/zero/1.0/","provider":"stocksnap","source":"stocksnap","tags":[{"name":"background"},{"name":"beak"},{"name":"bird"},{"name":"birdwatching"},{"name":"branch"},{"name":"closeup"},{"name":"copyspace"},{"name":"eye"},{"name":"feathered"},{"name":"feathers"},{"name":"habitat"},{"name":"hummingbird"},{"name":"nature"},{"name":"perched"},{"name":"sitting"},{"name":"wallpaper"},{"name":"wildlife"}],"fields_matched":["tags.name"],"thumbnail":"http://localhost:8000/v1/images/6d5cf6cb-f772-46fc-a3d9-99617be7731b/thumb/","detail_url":"http://localhost:8000/v1/images/6d5cf6cb-f772-46fc-a3d9-99617be7731b/","related_url":"http://localhost:8000/v1/images/6d5cf6cb-f772-46fc-a3d9-99617be7731b/related/"},{"id":"c09a61b6-374d-421a-be06-97215176f386","foreign_landing_url":"https://www.rawpixel.com/image/2268484/free-illustration-image-vintage-bird-art","creator":"Library of Congress","url":"https://img.rawpixel.com/s3fs-private/rawpixel_images/website_content/pd19batch37-099-gloy_3.jpg?w=1200&h=1200&fit=clip&crop=default&dpr=1&q=75&vib=3&con=3&usm=15&cs=srgb&bg=F4F4F3&ixlib=js-2.2.1&s=d59af605ed6adf9ed1490f3a989d8ecc","license":"cc0","license_version":"1.0","license_url":"https://creativecommons.org/publicdomain/zero/1.0/","provider":"rawpixel","source":"rawpixel","tags":[{"name":"1800s"},{"name":"1800s public domain"},{"name":"19th century"},{"name":"adolf glitsch"},{"name":"animal"},{"name":"animal graphics"},{"name":"animals public domain"},{"name":"antique"},{"name":"art"},{"name":"art forms of nature"},{"name":"art public domain"},{"name":"artwork"},{"name":"beak"},{"name":"bird"},{"name":"birds public domain"},{"name":"c* Connection #0 to host localhost left intact
olorful"},{"name":"copyright free public domain"},{"name":"design resource"},{"name":"ernst haeckel"},{"name":"feather"},{"name":"fly"},{"name":"high resolution"},{"name":"high resolution public domain"},{"name":"hummingbird"},{"name":"illustration"},{"name":"illustration public domain"},{"name":"kolibris"},{"name":"kunstformen der natur"},{"name":"natural"},{"name":"nature"},{"name":"old"},{"name":"poster"},{"name":"printable"},{"name":"public domain"},{"name":"public domain 1800s"},{"name":"public domain animals"},{"name":"public domain art"},{"name":"public domain birds"},{"name":"public domain images"},{"name":"public domain prints"},{"name":"royalty free public domain"},{"name":"scientific"},{"name":"trochilidae"},{"name":"vibrant"},{"name":"vintage"},{"name":"vintage illustration public domain"},{"name":"wall art"},{"name":"wild"},{"name":"wildlife"},{"name":"wing"}],"fields_matched":["tags.name"],"thumbnail":"http://localhost:8000/v1/images/c09a61b6-374d-421a-be06-97215176f386/thumb/","detail_url":"http://localhost:8000/v1/images/c09a61b6-374d-421a-be06-97215176f386/","related_url":"http://localhost:8000/v1/images/c09a61b6-374d-421a-be06-97215176f386/related/"}]}
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
