### PR TITLE
Capture log output before docker stack is torn down

### DIFF
--- a/ingestion_server/test/.gitignore
+++ b/ingestion_server/test/.gitignore
@@ -1,1 +1,2 @@
 integration-docker-compose.yml
+ingestion_logs.txt

--- a/ingestion_server/test/integration_test.py
+++ b/ingestion_server/test/integration_test.py
@@ -214,6 +214,16 @@ class TestIngestion(unittest.TestCase):
 
         # Stop all running containers and delete all data in volumes
         compose_path = cls.compose_path
+        log_output = compose_path.parent / "ingestion_logs.txt"
+        with log_output.open("w") as file:
+            subprocess.run(
+                ["docker-compose", "-f", compose_path.name, "logs"],
+                cwd=compose_path.parent,
+                check=True,
+                stderr=subprocess.STDOUT,
+                stdout=file,
+            )
+
         stop_cmd = ["docker-compose", "-f", compose_path.name, "down", "-v"]
         subprocess.run(
             stop_cmd,

--- a/ingestion_server/test/run_test.sh
+++ b/ingestion_server/test/run_test.sh
@@ -19,7 +19,7 @@ if [[ $succeeded -eq 0 ]]; then
 	printf "${green}:-) All tests passed${endcol}\n"
 else
   printf "Full system logs:\n"
-  docker-compose -f integration-docker-compose.yml logs
+  cat test/ingestion_logs.txt
 	printf "${red}:'( Some tests did not pass${endcol}\n"
 fi
 exit $succeeded


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Previously this would attempt to grab the logs on a stack that had already been removed, so there would be nothing to read. This will now pipe the logs to a file and then read from that file in the event of any failures. Logs are written unconditionally so they can be checked manually in success cases if desired.

The tests are also failing for me locally, but I wanted to get this change in on its own first if possible.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. `just int-testlocal`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
