### PR TITLE
Rename indices back to original during data refresh

### DIFF
--- a/ingestion_server/README.md
+++ b/ingestion_server/README.md
@@ -38,9 +38,12 @@ The server is designed to be run in a private network only. You must not expose 
 
 ## Running the tests
 
-<!-- TODO -->
+### Integration Tests
 
-#### Making requests
+The integration tests can be run using `just ing-testlocal`.
+Note that if a `.env` file exists in the folder you're running `just` from, it may interfere with the integration test variables and cause unexpected failures.
+
+### Making requests
 
 To make cURL requests to the server
 ```bash

--- a/ingestion_server/ingestion_server/ingest.py
+++ b/ingestion_server/ingestion_server/ingest.py
@@ -110,6 +110,7 @@ def _generate_indices(conn, table: str) -> tuple[list[str], dict[str, str]]:
             tokens[table_name_idx] = f"{schema_name}.temp_import_{table_name}"
             # This should do nothing?? All statements will be of the form
             # "CREATE INDEX ..." so a full check against just "id" will always fail.
+            # I'm too scared to remove it though so I'll do that in another pass.
             if "id" not in index:
                 cleaned.append(" ".join(tokens))
 

--- a/ingestion_server/ingestion_server/ingest.py
+++ b/ingestion_server/ingestion_server/ingest.py
@@ -109,7 +109,7 @@ def _generate_indices(conn, table: str):
     # Get all of the old indices from the existing table.
     with conn.cursor() as cur:
         get_idxs = SQL(
-            "SELECT indexdef " "FROM pg_indexes " "WHERE tablename = {table};"
+            "SELECT indexdef FROM pg_indexes WHERE tablename = {table};"
         ).format(table=Literal(table))
         cur.execute(get_idxs)
         idxs = cur.fetchall()

--- a/ingestion_server/ingestion_server/ingest.py
+++ b/ingestion_server/ingestion_server/ingest.py
@@ -291,6 +291,7 @@ def reload_upstream(table, progress=None, finish_time=None, approach="advanced")
         # Step 3: Import data into a temporary table
         log.info("Copying upstream data...")
         copy_data = get_copy_data_query(table, shared_cols, approach=approach)
+        log.info(f"Running copy-data query: \n{copy_data.as_string(downstream_cur)}")
         downstream_cur.execute(copy_data)
     downstream_db.commit()
     downstream_db.close()

--- a/ingestion_server/ingestion_server/ingest.py
+++ b/ingestion_server/ingestion_server/ingest.py
@@ -99,7 +99,7 @@ def _generate_indices(conn, table: str) -> tuple[list[str], dict[str, str]]:
             is_pk = "(id)" in index
             # Record what the old index was
             old_index = tokens[index_idx + 1]
-            # Primary keys during data refresh are based on the table name ane may
+            # Primary keys during data refresh are based on the table name and may
             # not be exactly correlated with what the primary keys are actually named
             new_index = (
                 f"temp_import_{old_index}" if not is_pk else f"temp_import_{table}_pkey"

--- a/ingestion_server/ingestion_server/ingest.py
+++ b/ingestion_server/ingestion_server/ingest.py
@@ -304,7 +304,6 @@ def reload_upstream(table, progress=None, finish_time=None, approach="advanced")
         # Step 5: Recreate indices from the original table
         log.info("Copying finished! Recreating database indices...")
         create_indices, index_mapping = _generate_indices(downstream_db, table)
-        print(f"{index_mapping=}")
         _update_progress(progress, 50.0)
         if create_indices != "":
             downstream_cur.execute(";\n".join(create_indices))

--- a/ingestion_server/mock_schemas/audio.sql
+++ b/ingestion_server/mock_schemas/audio.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 13.2
+-- Dumped from database version 13.3
 -- Dumped by pg_dump version 13.3 (Debian 13.3-1.pgdg100+1)
 
 SET statement_timeout = 0;
@@ -10,6 +10,7 @@ SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET xmloption = content;
 SET client_min_messages = warning;
@@ -42,7 +43,7 @@ CREATE TABLE public.audio (
     source character varying(80),
     last_synced_with_source timestamp with time zone,
     removed_from_source boolean NOT NULL,
-    view_count integer DEFAULT 0,
+    view_count integer,
     tags jsonb,
     tags_list character varying(255)[],
     meta_data jsonb,
@@ -55,124 +56,148 @@ CREATE TABLE public.audio (
     alt_files jsonb,
     thumbnail character varying(1000),
     filetype character varying(80),
-    audio_set_foreign_identifier character varying(1000),
-    standardized_popularity double precision
+    audio_set_foreign_identifier character varying(1000)
 );
 
 
 ALTER TABLE public.audio OWNER TO deploy;
 
 --
--- Name: audio temp_import_audio_pkey; Type: CONSTRAINT; Schema: public; Owner: deploy
+-- Name: audio_id_seq; Type: SEQUENCE; Schema: public; Owner: deploy
+--
+
+CREATE SEQUENCE public.audio_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.audio_id_seq OWNER TO deploy;
+
+--
+-- Name: audio_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: deploy
+--
+
+ALTER SEQUENCE public.audio_id_seq OWNED BY public.audio.id;
+
+
+--
+-- Name: audio id; Type: DEFAULT; Schema: public; Owner: deploy
+--
+
+ALTER TABLE ONLY public.audio ALTER COLUMN id SET DEFAULT nextval('public.audio_id_seq'::regclass);
+
+
+--
+-- Name: audio audio_identifier_key; Type: CONSTRAINT; Schema: public; Owner: deploy
 --
 
 ALTER TABLE ONLY public.audio
-    ADD CONSTRAINT temp_import_audio_pkey PRIMARY KEY (id);
+    ADD CONSTRAINT audio_identifier_key UNIQUE (identifier);
 
 
 --
--- Name: temp_import_audio_category_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: audio audio_pkey; Type: CONSTRAINT; Schema: public; Owner: deploy
 --
 
-CREATE INDEX temp_import_audio_category_idx ON public.audio USING btree (category);
-
-
---
--- Name: temp_import_audio_category_idx1; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE INDEX temp_import_audio_category_idx1 ON public.audio USING btree (category varchar_pattern_ops);
+ALTER TABLE ONLY public.audio
+    ADD CONSTRAINT audio_pkey PRIMARY KEY (id);
 
 
 --
--- Name: temp_import_audio_foreign_identifier_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: audio audio_url_key; Type: CONSTRAINT; Schema: public; Owner: deploy
 --
 
-CREATE INDEX temp_import_audio_foreign_identifier_idx ON public.audio USING btree (foreign_identifier varchar_pattern_ops);
-
-
---
--- Name: temp_import_audio_foreign_identifier_idx1; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE INDEX temp_import_audio_foreign_identifier_idx1 ON public.audio USING btree (foreign_identifier);
+ALTER TABLE ONLY public.audio
+    ADD CONSTRAINT audio_url_key UNIQUE (url);
 
 
 --
--- Name: temp_import_audio_foreign_identifier_provider_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: audio unique_provider_audio; Type: CONSTRAINT; Schema: public; Owner: deploy
 --
 
-CREATE UNIQUE INDEX temp_import_audio_foreign_identifier_provider_idx ON public.audio USING btree (foreign_identifier, provider);
-
-
---
--- Name: temp_import_audio_genres_idx; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE INDEX temp_import_audio_genres_idx ON public.audio USING btree (genres);
+ALTER TABLE ONLY public.audio
+    ADD CONSTRAINT unique_provider_audio UNIQUE (foreign_identifier, provider);
 
 
 --
--- Name: temp_import_audio_id_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: audio_category_ceb7d386; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE UNIQUE INDEX temp_import_audio_id_idx ON public.audio USING btree (id);
-
-
---
--- Name: temp_import_audio_identifier_idx; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE UNIQUE INDEX temp_import_audio_identifier_idx ON public.audio USING btree (identifier);
+CREATE INDEX audio_category_ceb7d386 ON public.audio USING btree (category);
 
 
 --
--- Name: temp_import_audio_last_synced_with_source_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: audio_category_ceb7d386_like; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE INDEX temp_import_audio_last_synced_with_source_idx ON public.audio USING btree (last_synced_with_source);
-
-
---
--- Name: temp_import_audio_provider_idx; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE INDEX temp_import_audio_provider_idx ON public.audio USING btree (provider);
+CREATE INDEX audio_category_ceb7d386_like ON public.audio USING btree (category varchar_pattern_ops);
 
 
 --
--- Name: temp_import_audio_provider_idx1; Type: INDEX; Schema: public; Owner: deploy
+-- Name: audio_foreign_identifier_617f66ad; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE INDEX temp_import_audio_provider_idx1 ON public.audio USING btree (provider varchar_pattern_ops);
-
-
---
--- Name: temp_import_audio_source_idx; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE INDEX temp_import_audio_source_idx ON public.audio USING btree (source);
+CREATE INDEX audio_foreign_identifier_617f66ad ON public.audio USING btree (foreign_identifier);
 
 
 --
--- Name: temp_import_audio_source_idx1; Type: INDEX; Schema: public; Owner: deploy
+-- Name: audio_foreign_identifier_617f66ad_like; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE INDEX temp_import_audio_source_idx1 ON public.audio USING btree (source varchar_pattern_ops);
-
-
---
--- Name: temp_import_audio_url_idx; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE UNIQUE INDEX temp_import_audio_url_idx ON public.audio USING btree (url);
+CREATE INDEX audio_foreign_identifier_617f66ad_like ON public.audio USING btree (foreign_identifier varchar_pattern_ops);
 
 
 --
--- Name: temp_import_audio_url_idx1; Type: INDEX; Schema: public; Owner: deploy
+-- Name: audio_genres_e34cc474; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE INDEX temp_import_audio_url_idx1 ON public.audio USING btree (url varchar_pattern_ops);
+CREATE INDEX audio_genres_e34cc474 ON public.audio USING btree (genres);
+
+
+--
+-- Name: audio_last_synced_with_source_94c4a383; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE INDEX audio_last_synced_with_source_94c4a383 ON public.audio USING btree (last_synced_with_source);
+
+
+--
+-- Name: audio_provider_8fe1eb54; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE INDEX audio_provider_8fe1eb54 ON public.audio USING btree (provider);
+
+
+--
+-- Name: audio_provider_8fe1eb54_like; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE INDEX audio_provider_8fe1eb54_like ON public.audio USING btree (provider varchar_pattern_ops);
+
+
+--
+-- Name: audio_source_e9ccc813; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE INDEX audio_source_e9ccc813 ON public.audio USING btree (source);
+
+
+--
+-- Name: audio_source_e9ccc813_like; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE INDEX audio_source_e9ccc813_like ON public.audio USING btree (source varchar_pattern_ops);
+
+
+--
+-- Name: audio_url_b6a832d3_like; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE INDEX audio_url_b6a832d3_like ON public.audio USING btree (url varchar_pattern_ops);
 
 
 --

--- a/ingestion_server/mock_schemas/image.sql
+++ b/ingestion_server/mock_schemas/image.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 13.2
+-- Dumped from database version 13.3
 -- Dumped by pg_dump version 13.3 (Debian 13.3-1.pgdg100+1)
 
 SET statement_timeout = 0;
@@ -10,6 +10,7 @@ SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET xmloption = content;
 SET client_min_messages = warning;
@@ -41,7 +42,7 @@ CREATE TABLE public.image (
     license_version character varying(25),
     creator character varying(2000),
     creator_url character varying(2000),
-    title character varying(2000),
+    title character varying(5000),
     tags_list character varying(255)[],
     last_synced_with_source timestamp with time zone,
     removed_from_source boolean NOT NULL,
@@ -50,102 +51,110 @@ CREATE TABLE public.image (
     tags jsonb,
     watermarked boolean,
     filetype character varying(80),
-    standardized_popularity double precision
+    standardized_popularity double precision,
+    category character varying(80)
 );
 
 
 ALTER TABLE public.image OWNER TO deploy;
 
 --
--- Name: image temp_import_image_pkey; Type: CONSTRAINT; Schema: public; Owner: deploy
+-- Name: image image_pkey; Type: CONSTRAINT; Schema: public; Owner: deploy
 --
 
 ALTER TABLE ONLY public.image
-    ADD CONSTRAINT temp_import_image_pkey PRIMARY KEY (id);
+    ADD CONSTRAINT image_pkey PRIMARY KEY (id);
 
 
 --
--- Name: temp_import_image_foreign_identifier_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: image_category_daa5d91c; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE INDEX temp_import_image_foreign_identifier_idx ON public.image USING btree (foreign_identifier varchar_pattern_ops);
-
-
---
--- Name: temp_import_image_foreign_identifier_idx1; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE INDEX temp_import_image_foreign_identifier_idx1 ON public.image USING btree (foreign_identifier);
+CREATE INDEX image_category_daa5d91c ON public.image USING btree (category);
 
 
 --
--- Name: temp_import_image_foreign_identifier_provider_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: image_category_daa5d91c_like; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE UNIQUE INDEX temp_import_image_foreign_identifier_provider_idx ON public.image USING btree (foreign_identifier, provider);
-
-
---
--- Name: temp_import_image_id_idx; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE UNIQUE INDEX temp_import_image_id_idx ON public.image USING btree (id);
+CREATE INDEX image_category_daa5d91c_like ON public.image USING btree (category varchar_pattern_ops);
 
 
 --
--- Name: temp_import_image_identifier_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: image_foreign_identifier_4c72d3ee; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE UNIQUE INDEX temp_import_image_identifier_idx ON public.image USING btree (identifier);
-
-
---
--- Name: temp_import_image_last_synced_with_source_idx; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE INDEX temp_import_image_last_synced_with_source_idx ON public.image USING btree (last_synced_with_source);
+CREATE INDEX image_foreign_identifier_4c72d3ee ON public.image USING btree (foreign_identifier);
 
 
 --
--- Name: temp_import_image_provider_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: image_foreign_identifier_4c72d3ee_like; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE INDEX temp_import_image_provider_idx ON public.image USING btree (provider);
-
-
---
--- Name: temp_import_image_provider_idx1; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE INDEX temp_import_image_provider_idx1 ON public.image USING btree (provider varchar_pattern_ops);
+CREATE INDEX image_foreign_identifier_4c72d3ee_like ON public.image USING btree (foreign_identifier varchar_pattern_ops);
 
 
 --
--- Name: temp_import_image_source_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: image_identifier_key; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE INDEX temp_import_image_source_idx ON public.image USING btree (source);
-
-
---
--- Name: temp_import_image_source_idx1; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE INDEX temp_import_image_source_idx1 ON public.image USING btree (source varchar_pattern_ops);
+CREATE UNIQUE INDEX image_identifier_key ON public.image USING btree (identifier);
 
 
 --
--- Name: temp_import_image_url_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: image_last_synced_with_source_187adf09; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE UNIQUE INDEX temp_import_image_url_idx ON public.image USING btree (url);
+CREATE INDEX image_last_synced_with_source_187adf09 ON public.image USING btree (last_synced_with_source);
 
 
 --
--- Name: temp_import_image_url_idx1; Type: INDEX; Schema: public; Owner: deploy
+-- Name: image_provider_7d11f847; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE INDEX temp_import_image_url_idx1 ON public.image USING btree (url varchar_pattern_ops);
+CREATE INDEX image_provider_7d11f847 ON public.image USING btree (provider);
+
+
+--
+-- Name: image_provider_7d11f847_like; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE INDEX image_provider_7d11f847_like ON public.image USING btree (provider varchar_pattern_ops);
+
+
+--
+-- Name: image_source_d5a89e97; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE INDEX image_source_d5a89e97 ON public.image USING btree (source);
+
+
+--
+-- Name: image_source_d5a89e97_like; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE INDEX image_source_d5a89e97_like ON public.image USING btree (source varchar_pattern_ops);
+
+
+--
+-- Name: image_url_c6aabda2_like; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE INDEX image_url_c6aabda2_like ON public.image USING btree (url varchar_pattern_ops);
+
+
+--
+-- Name: image_url_key; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE UNIQUE INDEX image_url_key ON public.image USING btree (url);
+
+
+--
+-- Name: unique_provider_image; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE UNIQUE INDEX unique_provider_image ON public.image USING btree (foreign_identifier, provider);
 
 
 --

--- a/ingestion_server/test/gen_integration_compose.py
+++ b/ingestion_server/test/gen_integration_compose.py
@@ -67,6 +67,26 @@ def _fixup_env(conf: dict):
     conf["services"]["ingestion_server"]["env_file"] = ["env.integration"]
 
 
+def _remove_volumes(conf: dict):
+    """
+    Remove the volumes from the compose configuration so that the images begin with
+    a fresh start on every startup.
+    :param conf: the Docker Compose configuration
+    """
+    volumes_to_remove = {
+        "db": "api-postgres",
+        "upstream_db": "catalog-postgres",
+        "es": "es-data",
+    }
+
+    for service, volume_to_remove in volumes_to_remove.items():
+        volumes = conf["services"][service]["volumes"]
+        volumes = [volume for volume in volumes if volume_to_remove not in volume]
+        conf["services"][service]["volumes"] = volumes
+
+    conf["volumes"] = {}
+
+
 def _change_directories(conf: dict):
     """
     Update the relative paths of the directories such as build context or bind
@@ -113,6 +133,10 @@ def gen_integration_compose():
 
         print("│ Updating environment variables... ", end="")
         _fixup_env(conf)
+        print("done")
+
+        print("│ Removing volumes... ", end="")
+        _remove_volumes(conf)
         print("done")
 
         print("│ Changing directories... ", end="")

--- a/ingestion_server/test/integration_test.py
+++ b/ingestion_server/test/integration_test.py
@@ -168,7 +168,8 @@ class TestIngestion(unittest.TestCase):
         """
         Strip out common keywords from the index to get a the name & columns.
         Indices take the form of:
-         CREATE [UNIQUE] INDEX {name} ON {table} USING btree {columns}
+          CREATE [UNIQUE] INDEX {name} ON {table} USING btree {columns}
+        Output will look like: ["my_special_index", "(my_column)"]
         """
         for token in [
             "CREATE",

--- a/ingestion_server/test/integration_test.py
+++ b/ingestion_server/test/integration_test.py
@@ -273,7 +273,7 @@ class TestIngestion(unittest.TestCase):
         Check that INGEST_UPSTREAM task completes successfully and responds
         with a callback.
         """
-        upstream_indices = self._get_indices(self.upstream_db, "image_view")
+        before_indices = self._get_indices(self.downstream_db, "image")
         req = {
             "model": "image",
             "action": "INGEST_UPSTREAM",
@@ -287,10 +287,10 @@ class TestIngestion(unittest.TestCase):
         assert self.__class__.cb_queue.get(timeout=120) == "CALLBACK!"
 
         # Check that the indices remained the same
-        downstream_indices = self._get_indices(self.downstream_db, "image")
+        after_indices = self._get_indices(self.downstream_db, "image")
         assert (
-            upstream_indices == downstream_indices
-        ), "Indices in downstream DB don't match those in the upstream DB after go-live"
+            before_indices == after_indices
+        ), "Indices in DB don't match the names they had before the go-live"
 
     @pytest.mark.order(3)
     def test_task_count_after_one(self):

--- a/ingestion_server/test/mock_schemas/README.md
+++ b/ingestion_server/test/mock_schemas/README.md
@@ -1,0 +1,7 @@
+# Mock schemas
+
+Files in this directory were created using the following command:
+
+```bash
+docker run --rm -e PGPASSWORD=<password> postgres:13 pg_dump -d openledger -h <url> -p 5432 -U deploy -t 'public.<table>' --schema-only
+```

--- a/ingestion_server/test/mock_schemas/audio.sql
+++ b/ingestion_server/test/mock_schemas/audio.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 13.2
+-- Dumped from database version 13.3
 -- Dumped by pg_dump version 13.3 (Debian 13.3-1.pgdg100+1)
 
 SET statement_timeout = 0;
@@ -10,6 +10,7 @@ SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET xmloption = content;
 SET client_min_messages = warning;
@@ -42,7 +43,7 @@ CREATE TABLE public.audio (
     source character varying(80),
     last_synced_with_source timestamp with time zone,
     removed_from_source boolean NOT NULL,
-    view_count integer DEFAULT 0,
+    view_count integer,
     tags jsonb,
     tags_list character varying(255)[],
     meta_data jsonb,
@@ -55,124 +56,148 @@ CREATE TABLE public.audio (
     alt_files jsonb,
     thumbnail character varying(1000),
     filetype character varying(80),
-    audio_set_foreign_identifier character varying(1000),
-    standardized_popularity double precision
+    audio_set_foreign_identifier character varying(1000)
 );
 
 
 ALTER TABLE public.audio OWNER TO deploy;
 
 --
--- Name: audio temp_import_audio_pkey; Type: CONSTRAINT; Schema: public; Owner: deploy
+-- Name: audio_id_seq; Type: SEQUENCE; Schema: public; Owner: deploy
+--
+
+CREATE SEQUENCE public.audio_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.audio_id_seq OWNER TO deploy;
+
+--
+-- Name: audio_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: deploy
+--
+
+ALTER SEQUENCE public.audio_id_seq OWNED BY public.audio.id;
+
+
+--
+-- Name: audio id; Type: DEFAULT; Schema: public; Owner: deploy
+--
+
+ALTER TABLE ONLY public.audio ALTER COLUMN id SET DEFAULT nextval('public.audio_id_seq'::regclass);
+
+
+--
+-- Name: audio audio_identifier_key; Type: CONSTRAINT; Schema: public; Owner: deploy
 --
 
 ALTER TABLE ONLY public.audio
-    ADD CONSTRAINT temp_import_audio_pkey PRIMARY KEY (id);
+    ADD CONSTRAINT audio_identifier_key UNIQUE (identifier);
 
 
 --
--- Name: temp_import_audio_category_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: audio audio_pkey; Type: CONSTRAINT; Schema: public; Owner: deploy
 --
 
-CREATE INDEX temp_import_audio_category_idx ON public.audio USING btree (category);
-
-
---
--- Name: temp_import_audio_category_idx1; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE INDEX temp_import_audio_category_idx1 ON public.audio USING btree (category varchar_pattern_ops);
+ALTER TABLE ONLY public.audio
+    ADD CONSTRAINT audio_pkey PRIMARY KEY (id);
 
 
 --
--- Name: temp_import_audio_foreign_identifier_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: audio audio_url_key; Type: CONSTRAINT; Schema: public; Owner: deploy
 --
 
-CREATE INDEX temp_import_audio_foreign_identifier_idx ON public.audio USING btree (foreign_identifier varchar_pattern_ops);
-
-
---
--- Name: temp_import_audio_foreign_identifier_idx1; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE INDEX temp_import_audio_foreign_identifier_idx1 ON public.audio USING btree (foreign_identifier);
+ALTER TABLE ONLY public.audio
+    ADD CONSTRAINT audio_url_key UNIQUE (url);
 
 
 --
--- Name: temp_import_audio_foreign_identifier_provider_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: audio unique_provider_audio; Type: CONSTRAINT; Schema: public; Owner: deploy
 --
 
-CREATE UNIQUE INDEX temp_import_audio_foreign_identifier_provider_idx ON public.audio USING btree (foreign_identifier, provider);
-
-
---
--- Name: temp_import_audio_genres_idx; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE INDEX temp_import_audio_genres_idx ON public.audio USING btree (genres);
+ALTER TABLE ONLY public.audio
+    ADD CONSTRAINT unique_provider_audio UNIQUE (foreign_identifier, provider);
 
 
 --
--- Name: temp_import_audio_id_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: audio_category_ceb7d386; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE UNIQUE INDEX temp_import_audio_id_idx ON public.audio USING btree (id);
-
-
---
--- Name: temp_import_audio_identifier_idx; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE UNIQUE INDEX temp_import_audio_identifier_idx ON public.audio USING btree (identifier);
+CREATE INDEX audio_category_ceb7d386 ON public.audio USING btree (category);
 
 
 --
--- Name: temp_import_audio_last_synced_with_source_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: audio_category_ceb7d386_like; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE INDEX temp_import_audio_last_synced_with_source_idx ON public.audio USING btree (last_synced_with_source);
-
-
---
--- Name: temp_import_audio_provider_idx; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE INDEX temp_import_audio_provider_idx ON public.audio USING btree (provider);
+CREATE INDEX audio_category_ceb7d386_like ON public.audio USING btree (category varchar_pattern_ops);
 
 
 --
--- Name: temp_import_audio_provider_idx1; Type: INDEX; Schema: public; Owner: deploy
+-- Name: audio_foreign_identifier_617f66ad; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE INDEX temp_import_audio_provider_idx1 ON public.audio USING btree (provider varchar_pattern_ops);
-
-
---
--- Name: temp_import_audio_source_idx; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE INDEX temp_import_audio_source_idx ON public.audio USING btree (source);
+CREATE INDEX audio_foreign_identifier_617f66ad ON public.audio USING btree (foreign_identifier);
 
 
 --
--- Name: temp_import_audio_source_idx1; Type: INDEX; Schema: public; Owner: deploy
+-- Name: audio_foreign_identifier_617f66ad_like; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE INDEX temp_import_audio_source_idx1 ON public.audio USING btree (source varchar_pattern_ops);
-
-
---
--- Name: temp_import_audio_url_idx; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE UNIQUE INDEX temp_import_audio_url_idx ON public.audio USING btree (url);
+CREATE INDEX audio_foreign_identifier_617f66ad_like ON public.audio USING btree (foreign_identifier varchar_pattern_ops);
 
 
 --
--- Name: temp_import_audio_url_idx1; Type: INDEX; Schema: public; Owner: deploy
+-- Name: audio_genres_e34cc474; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE INDEX temp_import_audio_url_idx1 ON public.audio USING btree (url varchar_pattern_ops);
+CREATE INDEX audio_genres_e34cc474 ON public.audio USING btree (genres);
+
+
+--
+-- Name: audio_last_synced_with_source_94c4a383; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE INDEX audio_last_synced_with_source_94c4a383 ON public.audio USING btree (last_synced_with_source);
+
+
+--
+-- Name: audio_provider_8fe1eb54; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE INDEX audio_provider_8fe1eb54 ON public.audio USING btree (provider);
+
+
+--
+-- Name: audio_provider_8fe1eb54_like; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE INDEX audio_provider_8fe1eb54_like ON public.audio USING btree (provider varchar_pattern_ops);
+
+
+--
+-- Name: audio_source_e9ccc813; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE INDEX audio_source_e9ccc813 ON public.audio USING btree (source);
+
+
+--
+-- Name: audio_source_e9ccc813_like; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE INDEX audio_source_e9ccc813_like ON public.audio USING btree (source varchar_pattern_ops);
+
+
+--
+-- Name: audio_url_b6a832d3_like; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE INDEX audio_url_b6a832d3_like ON public.audio USING btree (url varchar_pattern_ops);
 
 
 --

--- a/ingestion_server/test/mock_schemas/audioset.sql
+++ b/ingestion_server/test/mock_schemas/audioset.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 13.2
+-- Dumped from database version 13.3
 -- Dumped by pg_dump version 13.3 (Debian 13.3-1.pgdg100+1)
 
 SET statement_timeout = 0;
@@ -10,6 +10,7 @@ SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET xmloption = content;
 SET client_min_messages = warning;
@@ -25,8 +26,8 @@ SET default_table_access_method = heap;
 
 CREATE TABLE public.audioset (
     id integer NOT NULL,
-    created_on timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    updated_on timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    created_on timestamp with time zone NOT NULL,
+    updated_on timestamp with time zone NOT NULL,
     foreign_identifier character varying(1000),
     title character varying(2000),
     foreign_landing_url character varying(1000),
@@ -43,67 +44,91 @@ CREATE TABLE public.audioset (
 ALTER TABLE public.audioset OWNER TO deploy;
 
 --
--- Name: audioset temp_import_audioset_pkey; Type: CONSTRAINT; Schema: public; Owner: deploy
+-- Name: api_audioset_id_seq; Type: SEQUENCE; Schema: public; Owner: deploy
+--
+
+CREATE SEQUENCE public.api_audioset_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.api_audioset_id_seq OWNER TO deploy;
+
+--
+-- Name: api_audioset_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: deploy
+--
+
+ALTER SEQUENCE public.api_audioset_id_seq OWNED BY public.audioset.id;
+
+
+--
+-- Name: audioset id; Type: DEFAULT; Schema: public; Owner: deploy
+--
+
+ALTER TABLE ONLY public.audioset ALTER COLUMN id SET DEFAULT nextval('public.api_audioset_id_seq'::regclass);
+
+
+--
+-- Name: audioset api_audioset_pkey; Type: CONSTRAINT; Schema: public; Owner: deploy
 --
 
 ALTER TABLE ONLY public.audioset
-    ADD CONSTRAINT temp_import_audioset_pkey PRIMARY KEY (id);
+    ADD CONSTRAINT api_audioset_pkey PRIMARY KEY (id);
 
 
 --
--- Name: temp_import_audioset_foreign_identifier_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: audioset api_audioset_url_key; Type: CONSTRAINT; Schema: public; Owner: deploy
 --
 
-CREATE INDEX temp_import_audioset_foreign_identifier_idx ON public.audioset USING btree (foreign_identifier varchar_pattern_ops);
-
-
---
--- Name: temp_import_audioset_foreign_identifier_idx1; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE INDEX temp_import_audioset_foreign_identifier_idx1 ON public.audioset USING btree (foreign_identifier);
+ALTER TABLE ONLY public.audioset
+    ADD CONSTRAINT api_audioset_url_key UNIQUE (url);
 
 
 --
--- Name: temp_import_audioset_foreign_identifier_provider_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: audioset unique_foreign_identifier_provider; Type: CONSTRAINT; Schema: public; Owner: deploy
 --
 
-CREATE UNIQUE INDEX temp_import_audioset_foreign_identifier_provider_idx ON public.audioset USING btree (foreign_identifier, provider);
-
-
---
--- Name: temp_import_audioset_id_idx; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE UNIQUE INDEX temp_import_audioset_id_idx ON public.audioset USING btree (id);
+ALTER TABLE ONLY public.audioset
+    ADD CONSTRAINT unique_foreign_identifier_provider UNIQUE (foreign_identifier, provider);
 
 
 --
--- Name: temp_import_audioset_provider_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: api_audioset_foreign_identifier_28c1db59; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE INDEX temp_import_audioset_provider_idx ON public.audioset USING btree (provider);
-
-
---
--- Name: temp_import_audioset_provider_idx1; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE INDEX temp_import_audioset_provider_idx1 ON public.audioset USING btree (provider varchar_pattern_ops);
+CREATE INDEX api_audioset_foreign_identifier_28c1db59 ON public.audioset USING btree (foreign_identifier);
 
 
 --
--- Name: temp_import_audioset_url_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: api_audioset_foreign_identifier_28c1db59_like; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE UNIQUE INDEX temp_import_audioset_url_idx ON public.audioset USING btree (url);
+CREATE INDEX api_audioset_foreign_identifier_28c1db59_like ON public.audioset USING btree (foreign_identifier varchar_pattern_ops);
 
 
 --
--- Name: temp_import_audioset_url_idx1; Type: INDEX; Schema: public; Owner: deploy
+-- Name: api_audioset_url_200f9fb4_like; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE INDEX temp_import_audioset_url_idx1 ON public.audioset USING btree (url varchar_pattern_ops);
+CREATE INDEX api_audioset_url_200f9fb4_like ON public.audioset USING btree (url varchar_pattern_ops);
+
+
+--
+-- Name: audioset_provider_cc061f30; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE INDEX audioset_provider_cc061f30 ON public.audioset USING btree (provider);
+
+
+--
+-- Name: audioset_provider_cc061f30_like; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE INDEX audioset_provider_cc061f30_like ON public.audioset USING btree (provider varchar_pattern_ops);
 
 
 --

--- a/ingestion_server/test/mock_schemas/image.sql
+++ b/ingestion_server/test/mock_schemas/image.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 13.2
+-- Dumped from database version 13.3
 -- Dumped by pg_dump version 13.3 (Debian 13.3-1.pgdg100+1)
 
 SET statement_timeout = 0;
@@ -10,6 +10,7 @@ SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET xmloption = content;
 SET client_min_messages = warning;
@@ -41,7 +42,7 @@ CREATE TABLE public.image (
     license_version character varying(25),
     creator character varying(2000),
     creator_url character varying(2000),
-    title character varying(2000),
+    title character varying(5000),
     tags_list character varying(255)[],
     last_synced_with_source timestamp with time zone,
     removed_from_source boolean NOT NULL,
@@ -50,102 +51,110 @@ CREATE TABLE public.image (
     tags jsonb,
     watermarked boolean,
     filetype character varying(80),
-    standardized_popularity double precision
+    standardized_popularity double precision,
+    category character varying(80)
 );
 
 
 ALTER TABLE public.image OWNER TO deploy;
 
 --
--- Name: image temp_import_image_pkey; Type: CONSTRAINT; Schema: public; Owner: deploy
+-- Name: image image_pkey; Type: CONSTRAINT; Schema: public; Owner: deploy
 --
 
 ALTER TABLE ONLY public.image
-    ADD CONSTRAINT temp_import_image_pkey PRIMARY KEY (id);
+    ADD CONSTRAINT image_pkey PRIMARY KEY (id);
 
 
 --
--- Name: temp_import_image_foreign_identifier_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: image_category_daa5d91c; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE INDEX temp_import_image_foreign_identifier_idx ON public.image USING btree (foreign_identifier varchar_pattern_ops);
-
-
---
--- Name: temp_import_image_foreign_identifier_idx1; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE INDEX temp_import_image_foreign_identifier_idx1 ON public.image USING btree (foreign_identifier);
+CREATE INDEX image_category_daa5d91c ON public.image USING btree (category);
 
 
 --
--- Name: temp_import_image_foreign_identifier_provider_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: image_category_daa5d91c_like; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE UNIQUE INDEX temp_import_image_foreign_identifier_provider_idx ON public.image USING btree (foreign_identifier, provider);
-
-
---
--- Name: temp_import_image_id_idx; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE UNIQUE INDEX temp_import_image_id_idx ON public.image USING btree (id);
+CREATE INDEX image_category_daa5d91c_like ON public.image USING btree (category varchar_pattern_ops);
 
 
 --
--- Name: temp_import_image_identifier_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: image_foreign_identifier_4c72d3ee; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE UNIQUE INDEX temp_import_image_identifier_idx ON public.image USING btree (identifier);
-
-
---
--- Name: temp_import_image_last_synced_with_source_idx; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE INDEX temp_import_image_last_synced_with_source_idx ON public.image USING btree (last_synced_with_source);
+CREATE INDEX image_foreign_identifier_4c72d3ee ON public.image USING btree (foreign_identifier);
 
 
 --
--- Name: temp_import_image_provider_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: image_foreign_identifier_4c72d3ee_like; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE INDEX temp_import_image_provider_idx ON public.image USING btree (provider);
-
-
---
--- Name: temp_import_image_provider_idx1; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE INDEX temp_import_image_provider_idx1 ON public.image USING btree (provider varchar_pattern_ops);
+CREATE INDEX image_foreign_identifier_4c72d3ee_like ON public.image USING btree (foreign_identifier varchar_pattern_ops);
 
 
 --
--- Name: temp_import_image_source_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: image_identifier_key; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE INDEX temp_import_image_source_idx ON public.image USING btree (source);
-
-
---
--- Name: temp_import_image_source_idx1; Type: INDEX; Schema: public; Owner: deploy
---
-
-CREATE INDEX temp_import_image_source_idx1 ON public.image USING btree (source varchar_pattern_ops);
+CREATE UNIQUE INDEX image_identifier_key ON public.image USING btree (identifier);
 
 
 --
--- Name: temp_import_image_url_idx; Type: INDEX; Schema: public; Owner: deploy
+-- Name: image_last_synced_with_source_187adf09; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE UNIQUE INDEX temp_import_image_url_idx ON public.image USING btree (url);
+CREATE INDEX image_last_synced_with_source_187adf09 ON public.image USING btree (last_synced_with_source);
 
 
 --
--- Name: temp_import_image_url_idx1; Type: INDEX; Schema: public; Owner: deploy
+-- Name: image_provider_7d11f847; Type: INDEX; Schema: public; Owner: deploy
 --
 
-CREATE INDEX temp_import_image_url_idx1 ON public.image USING btree (url varchar_pattern_ops);
+CREATE INDEX image_provider_7d11f847 ON public.image USING btree (provider);
+
+
+--
+-- Name: image_provider_7d11f847_like; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE INDEX image_provider_7d11f847_like ON public.image USING btree (provider varchar_pattern_ops);
+
+
+--
+-- Name: image_source_d5a89e97; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE INDEX image_source_d5a89e97 ON public.image USING btree (source);
+
+
+--
+-- Name: image_source_d5a89e97_like; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE INDEX image_source_d5a89e97_like ON public.image USING btree (source varchar_pattern_ops);
+
+
+--
+-- Name: image_url_c6aabda2_like; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE INDEX image_url_c6aabda2_like ON public.image USING btree (url varchar_pattern_ops);
+
+
+--
+-- Name: image_url_key; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE UNIQUE INDEX image_url_key ON public.image USING btree (url);
+
+
+--
+-- Name: unique_provider_image; Type: INDEX; Schema: public; Owner: deploy
+--
+
+CREATE UNIQUE INDEX unique_provider_image ON public.image USING btree (foreign_identifier, provider);
 
 
 --

--- a/ingestion_server/test/run_test.sh
+++ b/ingestion_server/test/run_test.sh
@@ -12,7 +12,7 @@ TEST_ARG="${1:-test/}"
 
 PYTHONWARNINGS="ignore:Unverified HTTPS request" \
 PYTHONPATH=. \
-pytest -s --disable-pytest-warnings $TEST_ARG
+pytest -s -vv --disable-pytest-warnings $TEST_ARG
 
 succeeded=$?
 if [[ $succeeded -eq 0 ]]; then

--- a/ingestion_server/test/run_test.sh
+++ b/ingestion_server/test/run_test.sh
@@ -12,7 +12,7 @@ TEST_ARG="${1:-test/}"
 
 PYTHONWARNINGS="ignore:Unverified HTTPS request" \
 PYTHONPATH=. \
-pytest -s -vv --disable-pytest-warnings $TEST_ARG
+pytest -sx -vv --disable-pytest-warnings $TEST_ARG
 
 succeeded=$?
 if [[ $succeeded -eq 0 ]]; then

--- a/justfile
+++ b/justfile
@@ -137,8 +137,8 @@ _ing-api model action port="8001":
     just _ing-api {{ model }} "INGEST_UPSTREAM"
 
 # Run ingestion-server tests locally
-ing-testlocal:
-    cd ingestion_server && pipenv run ./test/run_test.sh
+ing-testlocal *args:
+    cd ingestion_server && pipenv run ./test/run_test.sh {{ args }}
 
 #######
 # API #


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #362 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR modifies the ingestion server so that it renames the indices of the target table back to the original during the go-live table swap. Previously this was not occurring, and so every subsequent run would add a `temp_import_` prefix to the target table (ultimately this would result in something like `temp_import_temp_import_temp_import_unique_url_idx`). The ingestion server now retains information about the original index names and uses them to rename the indices after the old target table has been removed. The integration tests will now also verify that the indices are unchanged after a data refresh.

Indices must unique globally across a database, but constraints need not be. While no logic change is necessary, I've also added a constraint check during the integration test similar to the index check.

Since I added volumes in #408, we want to make sure that we remove them for integration testing (even though we're performing `docker-compose down -v` and removing volumes, better safe than sorry!). I've added that step to the integration test setup. The tests are ordered and they're kind of dependent on the previous test succeeding, so I've also added a fail-fast option for when pytest is run.

I also simplified the integration tests since the `INGEST_UPSTREAM` tests between image/audio shared so much common logic.

Lastly, I added logging of the go-live query before it's actually run. That way we can make debugging easier for ourselves on this next run :smile:

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just ing-testlocal`! It's been flaky sometimes for me so let me know if the first data refresh test times out.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
