### PR TITLE
Override default RELATIVE_UPSTREAM_DB_* vars for integration tests

### DIFF
--- a/ingestion_server/test/env.integration
+++ b/ingestion_server/test/env.integration
@@ -7,6 +7,9 @@ DATABASE_HOST="integration_db"
 UPSTREAM_DB_HOST="integration_upstream_db"
 UPSTREAM_DB_PORT="5432"
 
+RELATIVE_UPSTREAM_DB_HOST="integration_upstream_db"
+RELATIVE_UPSTREAM_DB_PORT="5432"
+
 LOCK_PATH="/worker_state/lock"
 SHELF_PATH="/worker_state/db"
 SLACK_WEBHOOK=""


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #447 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR resolves an issue wherein the integration tests were failing after running `just env`. It turns out that [the decouple library](https://pypi.org/project/python-decouple/#env-file) (which is being used to [initialize the `RELATIVE_UPSTREAM_DB_*` variables](https://github.com/WordPress/openverse-api/blob/a7aa53ffc5f9d3b8b6bebf9dbacba248623a5a61/ingestion_server/ingestion_server/ingest.py#L43-L54)) was picking up the variables in the `.env` file created under the `ingestion_server` directory. Since `RELATIVE_UPSTREAM_DB_*` is explicitly defined in the `env.template` file, it was overriding the default, which would normally fall back to the `UPSTREAM_DB_*` values. Since the services are named differently for integration tests, this would then cause the tests to fail.

There are a few ways to correct this, but the easiest seemed to be just to explicitly define them in the environment file for the service since decouple gives precedence to environment variables over those loaded from a `.env` file.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. `just env`
1. `just ing-testlocal`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
