### PR TITLE
Add logger configuration to allow prod exception handling

### DIFF
--- a/api/catalog/logger.py
+++ b/api/catalog/logger.py
@@ -1,0 +1,82 @@
+from logging import LogRecord
+
+
+def health_check_filter(record: LogRecord) -> bool:
+    # Filter out health checks from the logs, they're verbose and happen frequently
+    return not ("GET /healthcheck" in record.getMessage() and record.status_code == 200)
+
+
+# Logging configuration
+LOGGING = {
+    # NOTE: Most of this is inherited from the default configuration
+    "version": 1,
+    "disable_existing_loggers": False,
+    "filters": {
+        "require_debug_false": {"()": "django.utils.log.RequireDebugFalse"},
+        "require_debug_true": {"()": "django.utils.log.RequireDebugTrue"},
+        "health_check": {
+            "()": "django.utils.log.CallbackFilter",
+            "callback": health_check_filter,
+        },
+    },
+    "formatters": {
+        "django.server": {
+            "()": "django.utils.log.ServerFormatter",
+            "format": "[{server_time}] {message}",
+            "style": "{",
+        },
+        "console": {
+            "format": "[%(asctime)s - %(name)s - %(lineno)3d][%(levelname)s] %(message)s",  # noqa
+        },
+    },
+    "handlers": {
+        # Default console logger
+        "console": {
+            "level": "INFO",
+            "filters": ["require_debug_true"],
+            "class": "logging.StreamHandler",
+            "formatter": "console",
+        },
+        # Add a clause to log error messages to the console in production
+        "console_prod": {
+            "level": "WARNING",
+            "filters": ["require_debug_false"],
+            "class": "logging.StreamHandler",
+            "formatter": "console",
+        },
+        # Handler for all other logging
+        "general_console": {
+            "level": "INFO",
+            "class": "logging.StreamHandler",
+            "formatter": "console",
+        },
+        # Default server logger
+        "django.server": {
+            "level": "INFO",
+            "class": "logging.StreamHandler",
+            "formatter": "django.server",
+        },
+        # Default mailing logger
+        "mail_admins": {
+            "level": "ERROR",
+            "filters": ["require_debug_false"],
+            "class": "django.utils.log.AdminEmailHandler",
+        },
+    },
+    "loggers": {
+        "django": {
+            "handlers": ["console", "console_prod", "mail_admins"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "django.server": {
+            "handlers": ["django.server"],
+            # Filter health check logs
+            "filters": ["health_check"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        # Default handler for all other loggers
+        "": {"handlers": ["general_console"], "level": "INFO"},
+    },
+}

--- a/api/catalog/settings.py
+++ b/api/catalog/settings.py
@@ -17,6 +17,8 @@ import sentry_sdk
 from decouple import config
 from sentry_sdk.integrations.django import DjangoIntegration
 
+from .logger import LOGGING  # noqa: F401
+
 
 # Build paths inside the project like this: BASE_DIR.join('dir', 'subdir'...)
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -247,29 +249,6 @@ AUTH_PASSWORD_VALIDATORS = [
         "NAME": "django.contrib.auth.password_validation" ".NumericPasswordValidator",
     },
 ]
-
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "handlers": {
-        "console": {
-            "level": "INFO",
-            "class": "logging.StreamHandler",
-        },
-    },
-    "loggers": {
-        "django": {
-            "handlers": ["console"],
-            "level": "INFO",
-            "propagate": True,
-        },
-        # root logger
-        "": {
-            "level": "INFO",
-            "handlers": ["console"],
-        },
-    },
-}
 
 # Internationalization
 # https://docs.djangoproject.com/en/2.0/topics/i18n/


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR adds some additional logging configuration to enable exception logging in production. Currently, when an exception or error occurs, we get unhelpful logs that look like this:

```
2022-01-07T13:06:57.964-08:00	Internal Server Error: /v1/audio/
2022-01-07T13:06:57.965-08:00	Internal Server Error: /v1/audio/
2022-01-07T13:06:57.984-08:00	Internal Server Error: /v1/audio/
2022-01-07T13:06:57.985-08:00	Internal Server Error: /v1/audio/
```

The above errors are HTTP 500 errors, but we aren't able to see any information about what is actually failing. The logging configuration in this PR ensures that:

1. Intentional logging within the service gets bubbled up appropriately
1. Django logging in general is set to `WARNING` in production
1. Exceptions are bubbled up to the logs appropriately in production

This does _not_ mean that users will see the debug view that Django provides in production. When we have `DEBUG=False`, all of that will be correctly hidden. This just makes it easier for us to troubleshoot production problems (particularly ones we can't replicate locally!).

I've used this config previously with great success! We also have the option to set up admin emails down the line where we'll receive an email on server errors. I think for a project of this size, that might be inadvisable and we would want a different way of aggregating/reporting errors.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
_Note that these steps are not to be committed and are only intended to replicate a production setup locally_
1. Set `DJANGO_DEBUG_ENABLED=False` in `api/env.docker`
1. Set the condition on line 54 of `settings.py` from `if DEBUG:` to `if True:`
1. Add an exception under the healthcheck view in `api/catalog/api/views/health_views.py` (I just added `raise ValueError("Whoops!")` above line 17)
1. `just up`
1. `just logs web`
1. Visit localhost:8000/healthcheck in your browser

If you follow these steps and are on `main`, you should receive an HTTP 500 error page and there should be nothing printed out in the logs (or at least not an exception). However if these steps are done on this branch, you should still receive the same generic HTTP 500 page in the browser, but the logs should contain the full exception traceback.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
