### PR TITLE
Handle error when audio set does not exist

### DIFF
--- a/api/catalog/api/models/audio.py
+++ b/api/catalog/api/models/audio.py
@@ -149,10 +149,13 @@ class Audio(AudioFileMixin, AbstractMedia):
 
     @property
     def audio_set(self):
-        return AudioSet.objects.get(
-            provider=self.provider,
-            foreign_identifier=self.audio_set_foreign_identifier,
-        )
+        try:
+            return AudioSet.objects.get(
+                provider=self.provider,
+                foreign_identifier=self.audio_set_foreign_identifier,
+            )
+        except AudioSet.DoesNotExist:
+            return None
 
     class Meta(AbstractMedia.Meta):
         db_table = "audio"


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Currently the API raises an error when accessing the thumbnail for an audio which has no audio set mapped to it. This PR fixes that error by wrapping the `.get` call in a `try...except` block.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
0. Check out the PR and run the server.
1. Access the thumbnail for an audio from the Wikimedia provider. Those usually don't belong to any audio set.
2. See a 404 error; before the PR it would have been a 500 error.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
