### PR TITLE
Add logging levels to Slack notifications in ingestion server

### DIFF
--- a/ingestion_server/ingestion_server/api.py
+++ b/ingestion_server/ingestion_server/api.py
@@ -156,7 +156,7 @@ class WorkerFinishedResource:
             index_type = target_index.split("-")[0]
             if index_type not in MEDIA_TYPES:
                 index_type = "image"
-            slack.message(
+            slack.verbose(
                 f"`{index_type}`: Elasticsearch reindex complete | "
                 f"_Next: promote index as primary_"
             )

--- a/ingestion_server/ingestion_server/indexer.py
+++ b/ingestion_server/ingestion_server/indexer.py
@@ -377,7 +377,7 @@ class TableIndexer:
         else:
             es.indices.put_alias(index=write_index, name=live_alias)
             log.info(f"Created '{live_alias}' index alias pointing to {write_index}")
-        slack.message(
+        slack.info(
             f"`{write_index}`: ES index promoted - data refresh complete! :tada:"
         )
 
@@ -414,7 +414,7 @@ class TableIndexer:
             schedule_distributed_index(database_connect(), destination_index)
         else:
             self._index_table(model_name, dest_idx=destination_index)
-            slack.message(
+            slack.verbose(
                 f"`{model_name}`: Elasticsearch reindex complete | "
                 f"_Next: promote index as primary_"
             )

--- a/ingestion_server/ingestion_server/ingest.py
+++ b/ingestion_server/ingestion_server/ingest.py
@@ -275,7 +275,7 @@ def reload_upstream(
     """
 
     # Step 1: Get the list of overlapping columns
-    slack.message(
+    slack.info(
         f"`{table}`: Starting data refresh | _Next: copying data from upstream_"
     )
     downstream_db = database_connect()
@@ -322,7 +322,7 @@ def reload_upstream(
         if table == "image"
         else "re-applying indices & constraints"
     )
-    slack.message(f"`{table}`: Data copy complete | _Next: {next_step}_")
+    slack.verbose(f"`{table}`: Data copy complete | _Next: {next_step}_")
     downstream_db.commit()
     downstream_db.close()
 
@@ -330,7 +330,7 @@ def reload_upstream(
         # Step 4: Clean the data
         log.info("Cleaning data...")
         clean_image_data(table)
-        slack.message(
+        slack.verbose(
             f"`{table}`: Data cleaning complete | "
             f"_Next: re-applying indices & constraints_"
         )
@@ -351,7 +351,7 @@ def reload_upstream(
         if len(remap_constraints.seq) != 0:
             downstream_cur.execute(remap_constraints)
         _update_progress(progress, 99.0)
-        slack.message(f"`{table}`: Indices & constraints applied | _Next: go-live_")
+        slack.verbose(f"`{table}`: Indices & constraints applied | _Next: go-live_")
 
         # Step 7: Promote the temporary table and delete the original
         log.info("Done remapping constraints! Going live with new table...")
@@ -362,7 +362,7 @@ def reload_upstream(
     downstream_db.close()
     log.info(f"Finished refreshing table '{table}'.")
     _update_progress(progress, 100.0)
-    slack.message(f"`{table}`: Finished table refresh | _Next: Elasticsearch reindex_")
+    slack.verbose(f"`{table}`: Finished table refresh | _Next: Elasticsearch reindex_")
 
     if finish_time:
         finish_time.value = datetime.datetime.utcnow().timestamp()

--- a/ingestion_server/ingestion_server/ingest.py
+++ b/ingestion_server/ingestion_server/ingest.py
@@ -275,9 +275,7 @@ def reload_upstream(
     """
 
     # Step 1: Get the list of overlapping columns
-    slack.info(
-        f"`{table}`: Starting data refresh | _Next: copying data from upstream_"
-    )
+    slack.info(f"`{table}`: Starting data refresh | _Next: copying data from upstream_")
     downstream_db = database_connect()
     upstream_db = psycopg2.connect(
         dbname=UPSTREAM_DB_NAME,

--- a/ingestion_server/ingestion_server/slack.py
+++ b/ingestion_server/ingestion_server/slack.py
@@ -5,6 +5,7 @@ from enum import Enum
 import requests
 from decouple import config
 
+
 log = logging.getLogger(__name__)
 SLACK_WEBHOOK = "SLACK_WEBHOOK"
 LOG_LEVEL = "SLACK_LOG_LEVEL"

--- a/ingestion_server/ingestion_server/tasks.py
+++ b/ingestion_server/ingestion_server/tasks.py
@@ -105,7 +105,7 @@ class Task(Process):
                 elasticsearch, self.model, self.progress, self.finish_time
             )
             if self.task_type == TaskTypes.REINDEX:
-                slack.message(f"`{self.model}`: Beginning Elasticsearch reindex")
+                slack.verbose(f"`{self.model}`: Beginning Elasticsearch reindex")
                 indexer.reindex(self.model)
             elif self.task_type == TaskTypes.UPDATE_INDEX:
                 indexer.update(self.model, self.since_date)
@@ -127,7 +127,7 @@ class Task(Process):
                     logging.error(e)
         except Exception as err:
             exception_type = f"{err.__class__.__module__}.{err.__class__.__name__}"
-            slack.message(
+            slack.error(
                 f":x_red: Error processing task `{self.task_type}` for `{self.model}` "
                 f"(`{exception_type}`): \n"
                 f"```\n{err}\n```"

--- a/ingestion_server/test/unit_tests/test_slack.py
+++ b/ingestion_server/test/unit_tests/test_slack.py
@@ -78,7 +78,7 @@ def test_message(
         (slack.verbose, None, True),
         (slack.info, None, True),
         (slack.error, None, True),
-    ]
+    ],
 )
 def test_log_levels(log_func, log_level, should_log, monkeypatch):
     monkeypatch.setenv("ENVIRONMENT", "staging")

--- a/ingestion_server/test/unit_tests/test_slack.py
+++ b/ingestion_server/test/unit_tests/test_slack.py
@@ -48,7 +48,7 @@ def test_message(
     monkeypatch.setenv("ENVIRONMENT", environment)
     monkeypatch.setenv(slack.SLACK_WEBHOOK, webhook)
     with mock.patch("requests.post") as mock_post:
-        slack.message(text, summary)
+        slack._message(text, summary)
         assert mock_post.called == should_alert
         if not should_alert:
             return
@@ -57,3 +57,62 @@ def test_message(
         assert data["text"] == expected_summary
         if environment:
             assert data["username"].endswith(environment.upper())
+
+@pytest.mark.parametrize(
+    "log_level, should_log",
+    [
+        ("ERROR", False),
+        ("INFO", False),
+        ("VERBOSE", True),
+        # If no log level set, verbose logging is enabled by default
+        (None, True)
+    ]
+)
+def test_verbose(log_level, should_log, monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "staging")
+    monkeypatch.setenv(slack.SLACK_WEBHOOK, "http://fake")
+    if log_level:
+        monkeypatch.setenv(slack.LOG_LEVEL, log_level)
+    with mock.patch("requests.post") as mock_post:
+        slack.verbose("text", "summary")
+        assert mock_post.called == should_log
+
+
+@pytest.mark.parametrize(
+    "log_level, should_log",
+    [
+        ("ERROR", False),
+        ("INFO", True),
+        ("VERBOSE", True),
+        # If no log level set, verbose logging is enabled by default
+        (None, True)
+    ]
+)
+def test_info(log_level, should_log, monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "staging")
+    monkeypatch.setenv(slack.SLACK_WEBHOOK, "http://fake")
+    if log_level:
+        monkeypatch.setenv(slack.LOG_LEVEL, log_level)
+    with mock.patch("requests.post") as mock_post:
+        slack.info("text", "summary")
+        assert mock_post.called == should_log
+
+
+@pytest.mark.parametrize(
+    "log_level, should_log",
+    [
+        ("ERROR", True),
+        ("INFO", True),
+        ("VERBOSE", True),
+        # If no log level set, verbose logging is enabled by default
+        (None, True)
+    ]
+)
+def test_error(log_level, should_log, monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "staging")
+    monkeypatch.setenv(slack.SLACK_WEBHOOK, "http://fake")
+    if log_level:
+        monkeypatch.setenv(slack.LOG_LEVEL, log_level)
+    with mock.patch("requests.post") as mock_post:
+        slack.error("text", "summary")
+        assert mock_post.called == should_log


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #481 by @AetherUnbound 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Adds Slack logging levels to the ingestion server; this lets us easily control the granularity of logging we need in a given environment. 
* Introduces `slack.error`, `slack.info`, and `slack.verbose` functions
    * `verbose` to be used for 'less important' messages; this allows an environment set at `INFO` to receive the most important info messages (data refresh start/stop) without triggering too many notifications.
        * I didn't use `trace`  for this because my understanding is that implies sensitive data and should not be used in production
    * We could easily add `warning`, `debug` etc if those become useful
* Updates existing slack notifications to use the new levels

The level is set using the `SLACK_LOG_LEVEL` environment variable. 

Notes/open questions:
* If the `SLACK_LOG_LEVEL` is not set, I've chosen to log at the `verbose` level by default. My reasoning was that's currently what we want in production, but I could certainly see a case for the exact opposite. What do folks think?

Because of this we should be able to deploy this without losing any logging in production (although we should still explicitly set the environment variable.) We can set staging to `INFO`.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the tests:
`just ing-testlocal`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
