### PR TITLE
Add throttle exemptions

### DIFF
--- a/api/Pipfile
+++ b/api/Pipfile
@@ -53,7 +53,6 @@ gunicorn = "*"
 sentry-sdk = "*"
 django-tqdm = "*"
 limit = "*"
-fakeredis = "*"
 
 [requires]
 python_version = "3.10"

--- a/api/Pipfile
+++ b/api/Pipfile
@@ -15,6 +15,7 @@ sphinx-autobuild = "*"
 furo = "*"
 myst-parser = "*"
 factory-boy = "*"
+fakeredis = "*"
 
 [packages]
 aws-requests-auth = "*"
@@ -52,6 +53,7 @@ gunicorn = "*"
 sentry-sdk = "*"
 django-tqdm = "*"
 limit = "*"
+fakeredis = "*"
 
 [requires]
 python_version = "3.10"

--- a/api/Pipfile.lock
+++ b/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8dbd649d6060f1d94a28016fe2b4a6aae3bfae224d37d7a9906cac8a92174868"
+            "sha256": "f90de180a4af8c71f26b68a4b0e7a30d3ab9829beb6c5f52264b5c734cc2660b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -305,14 +305,6 @@
             ],
             "index": "pypi",
             "version": "==7.4.0"
-        },
-        "fakeredis": {
-            "hashes": [
-                "sha256:7c2c4ba1b42e0a75337c54b777bf0671056b4569650e3ff927e4b9b385afc8ec",
-                "sha256:be3668e50f6b57d5fc4abfd27f9f655bed07a2c5aecfc8b15d0aad59f997c1ba"
-            ],
-            "index": "pypi",
-            "version": "==1.7.1"
         },
         "future": {
             "hashes": [
@@ -811,13 +803,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
-        },
-        "sortedcontainers": {
-            "hashes": [
-                "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88",
-                "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"
-            ],
-            "version": "==2.4.0"
         },
         "sqlparse": {
             "hashes": [

--- a/api/Pipfile.lock
+++ b/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0a42dcc7134e8d9f6064d5508f86ffbfbabbc1b7c77fbd1505f0f976c6bad0e9"
+            "sha256": "8dbd649d6060f1d94a28016fe2b4a6aae3bfae224d37d7a9906cac8a92174868"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -34,19 +34,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:20d29e7b845eed3a39b43633443859bfa719ddbe3c8702ddfd999bc737fba9db",
-                "sha256:d674fcd10c9603984599157941db66aa212d217dd073581c0ba2eab5e5da84fa"
+                "sha256:76d5b90400c54b25278150768e946edf166acce2c1597c0ecfbebb1dbe9acf2c",
+                "sha256:7bb2e6506a6ad44d111dd20a5d510374b6958fe989b4ef887109c79d812f926f"
             ],
             "index": "pypi",
-            "version": "==1.21.14"
+            "version": "==1.21.19"
         },
         "botocore": {
             "hashes": [
-                "sha256:2c40f4fc3925b9057869beda1413a7b77edb7a28eb05c6265eaf6ca1ca7d3b63",
-                "sha256:9fe55f6eab0977b00afd90e770ef2c8b989fa7b18e5c14b22ba62216ec3b564a"
+                "sha256:5ed2be0e413961134f4c17eab16396d41a5b4b73a637588260c04d20806d52ea",
+                "sha256:d0d77bce152ca51f3c2cd0f9bf05cb3b623e719406ad58b4c20444e237fe82eb"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.24.14"
+            "version": "==1.24.19"
         },
         "certifi": {
             "hashes": [
@@ -306,6 +306,14 @@
             "index": "pypi",
             "version": "==7.4.0"
         },
+        "fakeredis": {
+            "hashes": [
+                "sha256:7c2c4ba1b42e0a75337c54b777bf0671056b4569650e3ff927e4b9b385afc8ec",
+                "sha256:be3668e50f6b57d5fc4abfd27f9f655bed07a2c5aecfc8b15d0aad59f997c1ba"
+            ],
+            "index": "pypi",
+            "version": "==1.7.1"
+        },
         "future": {
             "hashes": [
                 "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
@@ -500,49 +508,49 @@
         },
         "markupsafe": {
             "hashes": [
-                "sha256:023af8c54fe63530545f70dd2a2a7eed18d07a9a77b94e8bf1e2ff7f252db9a3",
-                "sha256:09c86c9643cceb1d87ca08cdc30160d1b7ab49a8a21564868921959bd16441b8",
-                "sha256:142119fb14a1ef6d758912b25c4e803c3ff66920635c44078666fe7cc3f8f759",
-                "sha256:1d1fb9b2eec3c9714dd936860850300b51dbaa37404209c8d4cb66547884b7ed",
-                "sha256:204730fd5fe2fe3b1e9ccadb2bd18ba8712b111dcabce185af0b3b5285a7c989",
-                "sha256:24c3be29abb6b34052fd26fc7a8e0a49b1ee9d282e3665e8ad09a0a68faee5b3",
-                "sha256:290b02bab3c9e216da57c1d11d2ba73a9f73a614bbdcc027d299a60cdfabb11a",
-                "sha256:3028252424c72b2602a323f70fbf50aa80a5d3aa616ea6add4ba21ae9cc9da4c",
-                "sha256:30c653fde75a6e5eb814d2a0a89378f83d1d3f502ab710904ee585c38888816c",
-                "sha256:3cace1837bc84e63b3fd2dfce37f08f8c18aeb81ef5cf6bb9b51f625cb4e6cd8",
-                "sha256:4056f752015dfa9828dce3140dbadd543b555afb3252507348c493def166d454",
-                "sha256:454ffc1cbb75227d15667c09f164a0099159da0c1f3d2636aa648f12675491ad",
-                "sha256:598b65d74615c021423bd45c2bc5e9b59539c875a9bdb7e5f2a6b92dfcfc268d",
-                "sha256:599941da468f2cf22bf90a84f6e2a65524e87be2fce844f96f2dd9a6c9d1e635",
-                "sha256:5ddea4c352a488b5e1069069f2f501006b1a4362cb906bee9a193ef1245a7a61",
-                "sha256:62c0285e91414f5c8f621a17b69fc0088394ccdaa961ef469e833dbff64bd5ea",
-                "sha256:679cbb78914ab212c49c67ba2c7396dc599a8479de51b9a87b174700abd9ea49",
-                "sha256:6e104c0c2b4cd765b4e83909cde7ec61a1e313f8a75775897db321450e928cce",
-                "sha256:736895a020e31b428b3382a7887bfea96102c529530299f426bf2e636aacec9e",
-                "sha256:75bb36f134883fdbe13d8e63b8675f5f12b80bb6627f7714c7d6c5becf22719f",
-                "sha256:7d2f5d97fcbd004c03df8d8fe2b973fe2b14e7bfeb2cfa012eaa8759ce9a762f",
-                "sha256:80beaf63ddfbc64a0452b841d8036ca0611e049650e20afcb882f5d3c266d65f",
-                "sha256:84ad5e29bf8bab3ad70fd707d3c05524862bddc54dc040982b0dbcff36481de7",
-                "sha256:8da5924cb1f9064589767b0f3fc39d03e3d0fb5aa29e0cb21d43106519bd624a",
-                "sha256:961eb86e5be7d0973789f30ebcf6caab60b844203f4396ece27310295a6082c7",
-                "sha256:96de1932237abe0a13ba68b63e94113678c379dca45afa040a17b6e1ad7ed076",
-                "sha256:a0a0abef2ca47b33fb615b491ce31b055ef2430de52c5b3fb19a4042dbc5cadb",
-                "sha256:b2a5a856019d2833c56a3dcac1b80fe795c95f401818ea963594b345929dffa7",
-                "sha256:b8811d48078d1cf2a6863dafb896e68406c5f513048451cd2ded0473133473c7",
-                "sha256:c532d5ab79be0199fa2658e24a02fce8542df196e60665dd322409a03db6a52c",
-                "sha256:d3b64c65328cb4cd252c94f83e66e3d7acf8891e60ebf588d7b493a55a1dbf26",
-                "sha256:d4e702eea4a2903441f2735799d217f4ac1b55f7d8ad96ab7d4e25417cb0827c",
-                "sha256:d5653619b3eb5cbd35bfba3c12d575db2a74d15e0e1c08bf1db788069d410ce8",
-                "sha256:d66624f04de4af8bbf1c7f21cc06649c1c69a7f84109179add573ce35e46d448",
-                "sha256:e67ec74fada3841b8c5f4c4f197bea916025cb9aa3fe5abf7d52b655d042f956",
-                "sha256:e6f7f3f41faffaea6596da86ecc2389672fa949bd035251eab26dc6697451d05",
-                "sha256:f02cf7221d5cd915d7fa58ab64f7ee6dd0f6cddbb48683debf5d04ae9b1c2cc1",
-                "sha256:f0eddfcabd6936558ec020130f932d479930581171368fd728efcfb6ef0dd357",
-                "sha256:fabbe18087c3d33c5824cb145ffca52eccd053061df1d79d4b66dafa5ad2a5ea",
-                "sha256:fc3150f85e2dbcf99e65238c842d1cfe69d3e7649b19864c1cc043213d9cd730"
+                "sha256:0212a68688482dc52b2d45013df70d169f542b7394fc744c02a57374a4207003",
+                "sha256:089cf3dbf0cd6c100f02945abeb18484bd1ee57a079aefd52cffd17fba910b88",
+                "sha256:10c1bfff05d95783da83491be968e8fe789263689c02724e0c691933c52994f5",
+                "sha256:33b74d289bd2f5e527beadcaa3f401e0df0a89927c1559c8566c066fa4248ab7",
+                "sha256:3799351e2336dc91ea70b034983ee71cf2f9533cdff7c14c90ea126bfd95d65a",
+                "sha256:3ce11ee3f23f79dbd06fb3d63e2f6af7b12db1d46932fe7bd8afa259a5996603",
+                "sha256:421be9fbf0ffe9ffd7a378aafebbf6f4602d564d34be190fc19a193232fd12b1",
+                "sha256:43093fb83d8343aac0b1baa75516da6092f58f41200907ef92448ecab8825135",
+                "sha256:46d00d6cfecdde84d40e572d63735ef81423ad31184100411e6e3388d405e247",
+                "sha256:4a33dea2b688b3190ee12bd7cfa29d39c9ed176bda40bfa11099a3ce5d3a7ac6",
+                "sha256:4b9fe39a2ccc108a4accc2676e77da025ce383c108593d65cc909add5c3bd601",
+                "sha256:56442863ed2b06d19c37f94d999035e15ee982988920e12a5b4ba29b62ad1f77",
+                "sha256:671cd1187ed5e62818414afe79ed29da836dde67166a9fac6d435873c44fdd02",
+                "sha256:694deca8d702d5db21ec83983ce0bb4b26a578e71fbdbd4fdcd387daa90e4d5e",
+                "sha256:6a074d34ee7a5ce3effbc526b7083ec9731bb3cbf921bbe1d3005d4d2bdb3a63",
+                "sha256:6d0072fea50feec76a4c418096652f2c3238eaa014b2f94aeb1d56a66b41403f",
+                "sha256:6fbf47b5d3728c6aea2abb0589b5d30459e369baa772e0f37a0320185e87c980",
+                "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b",
+                "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812",
+                "sha256:8dc1c72a69aa7e082593c4a203dcf94ddb74bb5c8a731e4e1eb68d031e8498ff",
+                "sha256:8e3dcf21f367459434c18e71b2a9532d96547aef8a871872a5bd69a715c15f96",
+                "sha256:8e576a51ad59e4bfaac456023a78f6b5e6e7651dcd383bcc3e18d06f9b55d6d1",
+                "sha256:96e37a3dc86e80bf81758c152fe66dbf60ed5eca3d26305edf01892257049925",
+                "sha256:97a68e6ada378df82bc9f16b800ab77cbf4b2fada0081794318520138c088e4a",
+                "sha256:99a2a507ed3ac881b975a2976d59f38c19386d128e7a9a18b7df6fff1fd4c1d6",
+                "sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e",
+                "sha256:b09bf97215625a311f669476f44b8b318b075847b49316d3e28c08e41a7a573f",
+                "sha256:b7bd98b796e2b6553da7225aeb61f447f80a1ca64f41d83612e6139ca5213aa4",
+                "sha256:b87db4360013327109564f0e591bd2a3b318547bcef31b468a92ee504d07ae4f",
+                "sha256:bcb3ed405ed3222f9904899563d6fc492ff75cce56cba05e32eff40e6acbeaa3",
+                "sha256:d4306c36ca495956b6d568d276ac11fdd9c30a36f1b6eb928070dc5360b22e1c",
+                "sha256:d5ee4f386140395a2c818d149221149c54849dfcfcb9f1debfe07a8b8bd63f9a",
+                "sha256:dda30ba7e87fbbb7eab1ec9f58678558fd9a6b8b853530e176eabd064da81417",
+                "sha256:e04e26803c9c3851c931eac40c695602c6295b8d432cbe78609649ad9bd2da8a",
+                "sha256:e1c0b87e09fa55a220f058d1d49d3fb8df88fbfab58558f1198e08c1e1de842a",
+                "sha256:e72591e9ecd94d7feb70c1cbd7be7b3ebea3f548870aa91e2732960fa4d57a37",
+                "sha256:e8c843bbcda3a2f1e3c2ab25913c80a3c5376cd00c6e8c4a86a89a28c8dc5452",
+                "sha256:efc1913fd2ca4f334418481c7e595c00aad186563bbc1ec76067848c7ca0a933",
+                "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a",
+                "sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.1.0"
+            "version": "==2.1.1"
         },
         "oauthlib": {
             "hashes": [
@@ -804,6 +812,13 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
+        "sortedcontainers": {
+            "hashes": [
+                "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88",
+                "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"
+            ],
+            "version": "==2.4.0"
+        },
         "sqlparse": {
             "hashes": [
                 "sha256:0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae",
@@ -853,60 +868,73 @@
         },
         "wrapt": {
             "hashes": [
-                "sha256:086218a72ec7d986a3eddb7707c8c4526d677c7b35e355875a0fe2918b059179",
-                "sha256:0877fe981fd76b183711d767500e6b3111378ed2043c145e21816ee589d91096",
-                "sha256:0a017a667d1f7411816e4bf214646d0ad5b1da2c1ea13dec6c162736ff25a374",
-                "sha256:0cb23d36ed03bf46b894cfec777eec754146d68429c30431c99ef28482b5c1df",
-                "sha256:1fea9cd438686e6682271d36f3481a9f3636195578bab9ca3382e2f5f01fc185",
-                "sha256:220a869982ea9023e163ba915077816ca439489de6d2c09089b219f4e11b6785",
-                "sha256:25b1b1d5df495d82be1c9d2fad408f7ce5ca8a38085e2da41bb63c914baadff7",
-                "sha256:2dded5496e8f1592ec27079b28b6ad2a1ef0b9296d270f77b8e4a3a796cf6909",
-                "sha256:2ebdde19cd3c8cdf8df3fc165bc7827334bc4e353465048b36f7deeae8ee0918",
-                "sha256:43e69ffe47e3609a6aec0fe723001c60c65305784d964f5007d5b4fb1bc6bf33",
-                "sha256:46f7f3af321a573fc0c3586612db4decb7eb37172af1bc6173d81f5b66c2e068",
-                "sha256:47f0a183743e7f71f29e4e21574ad3fa95676136f45b91afcf83f6a050914829",
-                "sha256:498e6217523111d07cd67e87a791f5e9ee769f9241fcf8a379696e25806965af",
-                "sha256:4b9c458732450ec42578b5642ac53e312092acf8c0bfce140ada5ca1ac556f79",
-                "sha256:51799ca950cfee9396a87f4a1240622ac38973b6df5ef7a41e7f0b98797099ce",
-                "sha256:5601f44a0f38fed36cc07db004f0eedeaadbdcec90e4e90509480e7e6060a5bc",
-                "sha256:5f223101f21cfd41deec8ce3889dc59f88a59b409db028c469c9b20cfeefbe36",
-                "sha256:610f5f83dd1e0ad40254c306f4764fcdc846641f120c3cf424ff57a19d5f7ade",
-                "sha256:6a03d9917aee887690aa3f1747ce634e610f6db6f6b332b35c2dd89412912bca",
-                "sha256:705e2af1f7be4707e49ced9153f8d72131090e52be9278b5dbb1498c749a1e32",
-                "sha256:766b32c762e07e26f50d8a3468e3b4228b3736c805018e4b0ec8cc01ecd88125",
-                "sha256:77416e6b17926d953b5c666a3cb718d5945df63ecf922af0ee576206d7033b5e",
-                "sha256:778fd096ee96890c10ce96187c76b3e99b2da44e08c9e24d5652f356873f6709",
-                "sha256:78dea98c81915bbf510eb6a3c9c24915e4660302937b9ae05a0947164248020f",
-                "sha256:7dd215e4e8514004c8d810a73e342c536547038fb130205ec4bba9f5de35d45b",
-                "sha256:7dde79d007cd6dfa65afe404766057c2409316135cb892be4b1c768e3f3a11cb",
-                "sha256:81bd7c90d28a4b2e1df135bfbd7c23aee3050078ca6441bead44c42483f9ebfb",
-                "sha256:85148f4225287b6a0665eef08a178c15097366d46b210574a658c1ff5b377489",
-                "sha256:865c0b50003616f05858b22174c40ffc27a38e67359fa1495605f96125f76640",
-                "sha256:87883690cae293541e08ba2da22cacaae0a092e0ed56bbba8d018cc486fbafbb",
-                "sha256:8aab36778fa9bba1a8f06a4919556f9f8c7b33102bd71b3ab307bb3fecb21851",
-                "sha256:8c73c1a2ec7c98d7eaded149f6d225a692caa1bd7b2401a14125446e9e90410d",
-                "sha256:936503cb0a6ed28dbfa87e8fcd0a56458822144e9d11a49ccee6d9a8adb2ac44",
-                "sha256:944b180f61f5e36c0634d3202ba8509b986b5fbaf57db3e94df11abee244ba13",
-                "sha256:96b81ae75591a795d8c90edc0bfaab44d3d41ffc1aae4d994c5aa21d9b8e19a2",
-                "sha256:981da26722bebb9247a0601e2922cedf8bb7a600e89c852d063313102de6f2cb",
-                "sha256:ae9de71eb60940e58207f8e71fe113c639da42adb02fb2bcbcaccc1ccecd092b",
-                "sha256:b73d4b78807bd299b38e4598b8e7bd34ed55d480160d2e7fdaabd9931afa65f9",
-                "sha256:d4a5f6146cfa5c7ba0134249665acd322a70d1ea61732723c7d3e8cc0fa80755",
-                "sha256:dd91006848eb55af2159375134d724032a2d1d13bcc6f81cd8d3ed9f2b8e846c",
-                "sha256:e05e60ff3b2b0342153be4d1b597bbcfd8330890056b9619f4ad6b8d5c96a81a",
-                "sha256:e6906d6f48437dfd80464f7d7af1740eadc572b9f7a4301e7dd3d65db285cacf",
-                "sha256:e92d0d4fa68ea0c02d39f1e2f9cb5bc4b4a71e8c442207433d8db47ee79d7aa3",
-                "sha256:e94b7d9deaa4cc7bac9198a58a7240aaf87fe56c6277ee25fa5b3aa1edebd229",
-                "sha256:ea3e746e29d4000cd98d572f3ee2a6050a4f784bb536f4ac1f035987fc1ed83e",
-                "sha256:ec7e20258ecc5174029a0f391e1b948bf2906cd64c198a9b8b281b811cbc04de",
-                "sha256:ec9465dd69d5657b5d2fa6133b3e1e989ae27d29471a672416fd729b429eb554",
-                "sha256:f122ccd12fdc69628786d0c947bdd9cb2733be8f800d88b5a37c57f1f1d73c10",
-                "sha256:f99c0489258086308aad4ae57da9e8ecf9e1f3f30fa35d5e170b4d4896554d80",
-                "sha256:f9c51d9af9abb899bd34ace878fbec8bf357b3194a10c4e8e0a25512826ef056",
-                "sha256:fd76c47f20984b43d93de9a82011bb6e5f8325df6c9ed4d8310029a55fa361ea"
+                "sha256:00108411e0f34c52ce16f81f1d308a571df7784932cc7491d1e94be2ee93374b",
+                "sha256:01f799def9b96a8ec1ef6b9c1bbaf2bbc859b87545efbecc4a78faea13d0e3a0",
+                "sha256:09d16ae7a13cff43660155383a2372b4aa09109c7127aa3f24c3cf99b891c330",
+                "sha256:14e7e2c5f5fca67e9a6d5f753d21f138398cad2b1159913ec9e9a67745f09ba3",
+                "sha256:167e4793dc987f77fd476862d32fa404d42b71f6a85d3b38cbce711dba5e6b68",
+                "sha256:1807054aa7b61ad8d8103b3b30c9764de2e9d0c0978e9d3fc337e4e74bf25faa",
+                "sha256:1f83e9c21cd5275991076b2ba1cd35418af3504667affb4745b48937e214bafe",
+                "sha256:21b1106bff6ece8cb203ef45b4f5778d7226c941c83aaaa1e1f0f4f32cc148cd",
+                "sha256:22626dca56fd7f55a0733e604f1027277eb0f4f3d95ff28f15d27ac25a45f71b",
+                "sha256:23f96134a3aa24cc50614920cc087e22f87439053d886e474638c68c8d15dc80",
+                "sha256:2498762814dd7dd2a1d0248eda2afbc3dd9c11537bc8200a4b21789b6df6cd38",
+                "sha256:28c659878f684365d53cf59dc9a1929ea2eecd7ac65da762be8b1ba193f7e84f",
+                "sha256:2eca15d6b947cfff51ed76b2d60fd172c6ecd418ddab1c5126032d27f74bc350",
+                "sha256:354d9fc6b1e44750e2a67b4b108841f5f5ea08853453ecbf44c81fdc2e0d50bd",
+                "sha256:36a76a7527df8583112b24adc01748cd51a2d14e905b337a6fefa8b96fc708fb",
+                "sha256:3a0a4ca02752ced5f37498827e49c414d694ad7cf451ee850e3ff160f2bee9d3",
+                "sha256:3a71dbd792cc7a3d772ef8cd08d3048593f13d6f40a11f3427c000cf0a5b36a0",
+                "sha256:3a88254881e8a8c4784ecc9cb2249ff757fd94b911d5df9a5984961b96113fff",
+                "sha256:47045ed35481e857918ae78b54891fac0c1d197f22c95778e66302668309336c",
+                "sha256:4775a574e9d84e0212f5b18886cace049a42e13e12009bb0491562a48bb2b758",
+                "sha256:493da1f8b1bb8a623c16552fb4a1e164c0200447eb83d3f68b44315ead3f9036",
+                "sha256:4b847029e2d5e11fd536c9ac3136ddc3f54bc9488a75ef7d040a3900406a91eb",
+                "sha256:59d7d92cee84a547d91267f0fea381c363121d70fe90b12cd88241bd9b0e1763",
+                "sha256:5a0898a640559dec00f3614ffb11d97a2666ee9a2a6bad1259c9facd01a1d4d9",
+                "sha256:5a9a1889cc01ed2ed5f34574c90745fab1dd06ec2eee663e8ebeefe363e8efd7",
+                "sha256:5b835b86bd5a1bdbe257d610eecab07bf685b1af2a7563093e0e69180c1d4af1",
+                "sha256:5f24ca7953f2643d59a9c87d6e272d8adddd4a53bb62b9208f36db408d7aafc7",
+                "sha256:61e1a064906ccba038aa3c4a5a82f6199749efbbb3cef0804ae5c37f550eded0",
+                "sha256:65bf3eb34721bf18b5a021a1ad7aa05947a1767d1aa272b725728014475ea7d5",
+                "sha256:6807bcee549a8cb2f38f73f469703a1d8d5d990815c3004f21ddb68a567385ce",
+                "sha256:68aeefac31c1f73949662ba8affaf9950b9938b712fb9d428fa2a07e40ee57f8",
+                "sha256:6915682f9a9bc4cf2908e83caf5895a685da1fbd20b6d485dafb8e218a338279",
+                "sha256:6d9810d4f697d58fd66039ab959e6d37e63ab377008ef1d63904df25956c7db0",
+                "sha256:729d5e96566f44fccac6c4447ec2332636b4fe273f03da128fff8d5559782b06",
+                "sha256:748df39ed634851350efa87690c2237a678ed794fe9ede3f0d79f071ee042561",
+                "sha256:763a73ab377390e2af26042f685a26787c402390f682443727b847e9496e4a2a",
+                "sha256:8323a43bd9c91f62bb7d4be74cc9ff10090e7ef820e27bfe8815c57e68261311",
+                "sha256:8529b07b49b2d89d6917cfa157d3ea1dfb4d319d51e23030664a827fe5fd2131",
+                "sha256:87fa943e8bbe40c8c1ba4086971a6fefbf75e9991217c55ed1bcb2f1985bd3d4",
+                "sha256:88236b90dda77f0394f878324cfbae05ae6fde8a84d548cfe73a75278d760291",
+                "sha256:891c353e95bb11abb548ca95c8b98050f3620a7378332eb90d6acdef35b401d4",
+                "sha256:89ba3d548ee1e6291a20f3c7380c92f71e358ce8b9e48161401e087e0bc740f8",
+                "sha256:8c6be72eac3c14baa473620e04f74186c5d8f45d80f8f2b4eda6e1d18af808e8",
+                "sha256:9a242871b3d8eecc56d350e5e03ea1854de47b17f040446da0e47dc3e0b9ad4d",
+                "sha256:9a3ff5fb015f6feb78340143584d9f8a0b91b6293d6b5cf4295b3e95d179b88c",
+                "sha256:9a5a544861b21e0e7575b6023adebe7a8c6321127bb1d238eb40d99803a0e8bd",
+                "sha256:9d57677238a0c5411c76097b8b93bdebb02eb845814c90f0b01727527a179e4d",
+                "sha256:9d8c68c4145041b4eeae96239802cfdfd9ef927754a5be3f50505f09f309d8c6",
+                "sha256:9d9fcd06c952efa4b6b95f3d788a819b7f33d11bea377be6b8980c95e7d10775",
+                "sha256:a0057b5435a65b933cbf5d859cd4956624df37b8bf0917c71756e4b3d9958b9e",
+                "sha256:a65bffd24409454b889af33b6c49d0d9bcd1a219b972fba975ac935f17bdf627",
+                "sha256:b0ed6ad6c9640671689c2dbe6244680fe8b897c08fd1fab2228429b66c518e5e",
+                "sha256:b21650fa6907e523869e0396c5bd591cc326e5c1dd594dcdccac089561cacfb8",
+                "sha256:b3f7e671fb19734c872566e57ce7fc235fa953d7c181bb4ef138e17d607dc8a1",
+                "sha256:b77159d9862374da213f741af0c361720200ab7ad21b9f12556e0eb95912cd48",
+                "sha256:bb36fbb48b22985d13a6b496ea5fb9bb2a076fea943831643836c9f6febbcfdc",
+                "sha256:d066ffc5ed0be00cd0352c95800a519cf9e4b5dd34a028d301bdc7177c72daf3",
+                "sha256:d332eecf307fca852d02b63f35a7872de32d5ba8b4ec32da82f45df986b39ff6",
+                "sha256:d808a5a5411982a09fef6b49aac62986274ab050e9d3e9817ad65b2791ed1425",
+                "sha256:d9bdfa74d369256e4218000a629978590fd7cb6cf6893251dad13d051090436d",
+                "sha256:db6a0ddc1282ceb9032e41853e659c9b638789be38e5b8ad7498caac00231c23",
+                "sha256:debaf04f813ada978d7d16c7dfa16f3c9c2ec9adf4656efdc4defdf841fc2f0c",
+                "sha256:f0408e2dbad9e82b4c960274214af533f856a199c9274bd4aff55d4634dedc33",
+                "sha256:f2f3bc7cd9c9fcd39143f11342eb5963317bd54ecc98e3650ca22704b69d9653"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==1.13.3"
+            "version": "==1.14.0"
         },
         "wsgi-basic-auth": {
             "hashes": [
@@ -1149,6 +1177,14 @@
             "markers": "python_version >= '3.5'",
             "version": "==5.1.1"
         },
+        "deprecated": {
+            "hashes": [
+                "sha256:43ac5335da90c31c24ba028af536a91d41d53f9e6901ddb021bcc572ce44e38d",
+                "sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.2.13"
+        },
         "distlib": {
             "hashes": [
                 "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b",
@@ -1181,11 +1217,19 @@
         },
         "faker": {
             "hashes": [
-                "sha256:c88c8b5ee9376a242deca8fe829f9a3215ffa43c31da6f66d9594531fb344453",
-                "sha256:fa060e331ffffb57cfa4c07f95d54911e339984ed72596ba6a9e7b6fa569d799"
+                "sha256:66db859b6abe376d02e805ad81eb8dcfce38f0945f17ee7cdf74ed349985ea52",
+                "sha256:fe969607836ce7100e38b88dcb598aacb733d895e6e9401894dd603e35623000"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==13.3.1"
+            "version": "==13.3.2"
+        },
+        "fakeredis": {
+            "hashes": [
+                "sha256:7c2c4ba1b42e0a75337c54b777bf0671056b4569650e3ff927e4b9b385afc8ec",
+                "sha256:be3668e50f6b57d5fc4abfd27f9f655bed07a2c5aecfc8b15d0aad59f997c1ba"
+            ],
+            "index": "pypi",
+            "version": "==1.7.1"
         },
         "filelock": {
             "hashes": [
@@ -1412,11 +1456,11 @@
         },
         "itsdangerous": {
             "hashes": [
-                "sha256:29285842166554469a56d427addc0843914172343784cb909695fdbe90a3e129",
-                "sha256:d848fcb8bc7d507c4546b448574e8a44fc4ea2ba84ebf8d783290d53e81992f5"
+                "sha256:7b7d3023cd35d9cb0c1fd91392f8c95c6fa02c59bf8ad64b8849be3401b95afb",
+                "sha256:935642cd4b987cdbee7210080004033af76306757ff8b4c0a506a4b6e06f02cf"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.1.0"
+            "version": "==2.1.1"
         },
         "jedi": {
             "hashes": [
@@ -1442,11 +1486,11 @@
         },
         "locust": {
             "hashes": [
-                "sha256:9c5110bdaf2d6ab72d68091e6685abf20bd138df711fde8dc88d81b8cb012b78",
-                "sha256:f111db4de7871c8e591653b2c6f66526b463a19883948d0e43dd9fb482e7dbb6"
+                "sha256:369aaa62d71a57b3f74e3b6dc679467af97952a1517a527a5fceed1ed6763a7d",
+                "sha256:fc195ecccf53248166d5ab30d88d2577ca6a7a139b4f784986b62cae2419297b"
             ],
             "index": "pypi",
-            "version": "==2.8.3"
+            "version": "==2.8.4"
         },
         "markdown-it-py": {
             "hashes": [
@@ -1458,49 +1502,49 @@
         },
         "markupsafe": {
             "hashes": [
-                "sha256:023af8c54fe63530545f70dd2a2a7eed18d07a9a77b94e8bf1e2ff7f252db9a3",
-                "sha256:09c86c9643cceb1d87ca08cdc30160d1b7ab49a8a21564868921959bd16441b8",
-                "sha256:142119fb14a1ef6d758912b25c4e803c3ff66920635c44078666fe7cc3f8f759",
-                "sha256:1d1fb9b2eec3c9714dd936860850300b51dbaa37404209c8d4cb66547884b7ed",
-                "sha256:204730fd5fe2fe3b1e9ccadb2bd18ba8712b111dcabce185af0b3b5285a7c989",
-                "sha256:24c3be29abb6b34052fd26fc7a8e0a49b1ee9d282e3665e8ad09a0a68faee5b3",
-                "sha256:290b02bab3c9e216da57c1d11d2ba73a9f73a614bbdcc027d299a60cdfabb11a",
-                "sha256:3028252424c72b2602a323f70fbf50aa80a5d3aa616ea6add4ba21ae9cc9da4c",
-                "sha256:30c653fde75a6e5eb814d2a0a89378f83d1d3f502ab710904ee585c38888816c",
-                "sha256:3cace1837bc84e63b3fd2dfce37f08f8c18aeb81ef5cf6bb9b51f625cb4e6cd8",
-                "sha256:4056f752015dfa9828dce3140dbadd543b555afb3252507348c493def166d454",
-                "sha256:454ffc1cbb75227d15667c09f164a0099159da0c1f3d2636aa648f12675491ad",
-                "sha256:598b65d74615c021423bd45c2bc5e9b59539c875a9bdb7e5f2a6b92dfcfc268d",
-                "sha256:599941da468f2cf22bf90a84f6e2a65524e87be2fce844f96f2dd9a6c9d1e635",
-                "sha256:5ddea4c352a488b5e1069069f2f501006b1a4362cb906bee9a193ef1245a7a61",
-                "sha256:62c0285e91414f5c8f621a17b69fc0088394ccdaa961ef469e833dbff64bd5ea",
-                "sha256:679cbb78914ab212c49c67ba2c7396dc599a8479de51b9a87b174700abd9ea49",
-                "sha256:6e104c0c2b4cd765b4e83909cde7ec61a1e313f8a75775897db321450e928cce",
-                "sha256:736895a020e31b428b3382a7887bfea96102c529530299f426bf2e636aacec9e",
-                "sha256:75bb36f134883fdbe13d8e63b8675f5f12b80bb6627f7714c7d6c5becf22719f",
-                "sha256:7d2f5d97fcbd004c03df8d8fe2b973fe2b14e7bfeb2cfa012eaa8759ce9a762f",
-                "sha256:80beaf63ddfbc64a0452b841d8036ca0611e049650e20afcb882f5d3c266d65f",
-                "sha256:84ad5e29bf8bab3ad70fd707d3c05524862bddc54dc040982b0dbcff36481de7",
-                "sha256:8da5924cb1f9064589767b0f3fc39d03e3d0fb5aa29e0cb21d43106519bd624a",
-                "sha256:961eb86e5be7d0973789f30ebcf6caab60b844203f4396ece27310295a6082c7",
-                "sha256:96de1932237abe0a13ba68b63e94113678c379dca45afa040a17b6e1ad7ed076",
-                "sha256:a0a0abef2ca47b33fb615b491ce31b055ef2430de52c5b3fb19a4042dbc5cadb",
-                "sha256:b2a5a856019d2833c56a3dcac1b80fe795c95f401818ea963594b345929dffa7",
-                "sha256:b8811d48078d1cf2a6863dafb896e68406c5f513048451cd2ded0473133473c7",
-                "sha256:c532d5ab79be0199fa2658e24a02fce8542df196e60665dd322409a03db6a52c",
-                "sha256:d3b64c65328cb4cd252c94f83e66e3d7acf8891e60ebf588d7b493a55a1dbf26",
-                "sha256:d4e702eea4a2903441f2735799d217f4ac1b55f7d8ad96ab7d4e25417cb0827c",
-                "sha256:d5653619b3eb5cbd35bfba3c12d575db2a74d15e0e1c08bf1db788069d410ce8",
-                "sha256:d66624f04de4af8bbf1c7f21cc06649c1c69a7f84109179add573ce35e46d448",
-                "sha256:e67ec74fada3841b8c5f4c4f197bea916025cb9aa3fe5abf7d52b655d042f956",
-                "sha256:e6f7f3f41faffaea6596da86ecc2389672fa949bd035251eab26dc6697451d05",
-                "sha256:f02cf7221d5cd915d7fa58ab64f7ee6dd0f6cddbb48683debf5d04ae9b1c2cc1",
-                "sha256:f0eddfcabd6936558ec020130f932d479930581171368fd728efcfb6ef0dd357",
-                "sha256:fabbe18087c3d33c5824cb145ffca52eccd053061df1d79d4b66dafa5ad2a5ea",
-                "sha256:fc3150f85e2dbcf99e65238c842d1cfe69d3e7649b19864c1cc043213d9cd730"
+                "sha256:0212a68688482dc52b2d45013df70d169f542b7394fc744c02a57374a4207003",
+                "sha256:089cf3dbf0cd6c100f02945abeb18484bd1ee57a079aefd52cffd17fba910b88",
+                "sha256:10c1bfff05d95783da83491be968e8fe789263689c02724e0c691933c52994f5",
+                "sha256:33b74d289bd2f5e527beadcaa3f401e0df0a89927c1559c8566c066fa4248ab7",
+                "sha256:3799351e2336dc91ea70b034983ee71cf2f9533cdff7c14c90ea126bfd95d65a",
+                "sha256:3ce11ee3f23f79dbd06fb3d63e2f6af7b12db1d46932fe7bd8afa259a5996603",
+                "sha256:421be9fbf0ffe9ffd7a378aafebbf6f4602d564d34be190fc19a193232fd12b1",
+                "sha256:43093fb83d8343aac0b1baa75516da6092f58f41200907ef92448ecab8825135",
+                "sha256:46d00d6cfecdde84d40e572d63735ef81423ad31184100411e6e3388d405e247",
+                "sha256:4a33dea2b688b3190ee12bd7cfa29d39c9ed176bda40bfa11099a3ce5d3a7ac6",
+                "sha256:4b9fe39a2ccc108a4accc2676e77da025ce383c108593d65cc909add5c3bd601",
+                "sha256:56442863ed2b06d19c37f94d999035e15ee982988920e12a5b4ba29b62ad1f77",
+                "sha256:671cd1187ed5e62818414afe79ed29da836dde67166a9fac6d435873c44fdd02",
+                "sha256:694deca8d702d5db21ec83983ce0bb4b26a578e71fbdbd4fdcd387daa90e4d5e",
+                "sha256:6a074d34ee7a5ce3effbc526b7083ec9731bb3cbf921bbe1d3005d4d2bdb3a63",
+                "sha256:6d0072fea50feec76a4c418096652f2c3238eaa014b2f94aeb1d56a66b41403f",
+                "sha256:6fbf47b5d3728c6aea2abb0589b5d30459e369baa772e0f37a0320185e87c980",
+                "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b",
+                "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812",
+                "sha256:8dc1c72a69aa7e082593c4a203dcf94ddb74bb5c8a731e4e1eb68d031e8498ff",
+                "sha256:8e3dcf21f367459434c18e71b2a9532d96547aef8a871872a5bd69a715c15f96",
+                "sha256:8e576a51ad59e4bfaac456023a78f6b5e6e7651dcd383bcc3e18d06f9b55d6d1",
+                "sha256:96e37a3dc86e80bf81758c152fe66dbf60ed5eca3d26305edf01892257049925",
+                "sha256:97a68e6ada378df82bc9f16b800ab77cbf4b2fada0081794318520138c088e4a",
+                "sha256:99a2a507ed3ac881b975a2976d59f38c19386d128e7a9a18b7df6fff1fd4c1d6",
+                "sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e",
+                "sha256:b09bf97215625a311f669476f44b8b318b075847b49316d3e28c08e41a7a573f",
+                "sha256:b7bd98b796e2b6553da7225aeb61f447f80a1ca64f41d83612e6139ca5213aa4",
+                "sha256:b87db4360013327109564f0e591bd2a3b318547bcef31b468a92ee504d07ae4f",
+                "sha256:bcb3ed405ed3222f9904899563d6fc492ff75cce56cba05e32eff40e6acbeaa3",
+                "sha256:d4306c36ca495956b6d568d276ac11fdd9c30a36f1b6eb928070dc5360b22e1c",
+                "sha256:d5ee4f386140395a2c818d149221149c54849dfcfcb9f1debfe07a8b8bd63f9a",
+                "sha256:dda30ba7e87fbbb7eab1ec9f58678558fd9a6b8b853530e176eabd064da81417",
+                "sha256:e04e26803c9c3851c931eac40c695602c6295b8d432cbe78609649ad9bd2da8a",
+                "sha256:e1c0b87e09fa55a220f058d1d49d3fb8df88fbfab58558f1198e08c1e1de842a",
+                "sha256:e72591e9ecd94d7feb70c1cbd7be7b3ebea3f548870aa91e2732960fa4d57a37",
+                "sha256:e8c843bbcda3a2f1e3c2ab25913c80a3c5376cd00c6e8c4a86a89a28c8dc5452",
+                "sha256:efc1913fd2ca4f334418481c7e595c00aad186563bbc1ec76067848c7ca0a933",
+                "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a",
+                "sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.1.0"
+            "version": "==2.1.1"
         },
         "matplotlib-inline": {
             "hashes": [
@@ -1729,11 +1773,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db",
-                "sha256:e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171"
+                "sha256:b555252a95bbb2a37a97b5ac2eb050c436f7989993565f5e0c9128fcaacadd0e",
+                "sha256:f1089d218cfcc63a212c42896f1b7fbf096874d045e1988186861a1a87d27b47"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==7.0.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==7.1.0"
         },
         "pytest-django": {
             "hashes": [
@@ -1850,6 +1894,14 @@
             "markers": "python_version >= '3.6'",
             "version": "==22.3.0"
         },
+        "redis": {
+            "hashes": [
+                "sha256:04629f8e42be942c4f7d1812f2094568f04c612865ad19ad3ace3005da70631a",
+                "sha256:1d9a0cdf89fdd93f84261733e24f55a7bbd413a9b219fdaf56e3e728ca9a2306"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==4.1.4"
+        },
         "remote-pdb": {
             "hashes": [
                 "sha256:2d70c6f41e0eabf0165e8f1be58f82aa7a605aaeab8f2aefeb9ce246431091c1",
@@ -1894,6 +1946,13 @@
                 "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"
             ],
             "version": "==2.2.0"
+        },
+        "sortedcontainers": {
+            "hashes": [
+                "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88",
+                "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"
+            ],
+            "version": "==2.4.0"
         },
         "soupsieve": {
             "hashes": [
@@ -2034,7 +2093,7 @@
                 "sha256:fa2ba70284fa42c2a5ecb35e322e68823288a4251f9ba9cc77be04ae15eada68",
                 "sha256:fba85b6cd9c39be262fcd23865652920832b61583de2a2ca907dbd8e8a8c81e5"
             ],
-            "markers": "python_version > '2.7'",
+            "markers": "python_version >= '3.5'",
             "version": "==6.1"
         },
         "traitlets": {
@@ -2083,6 +2142,76 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==2.0.3"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:00108411e0f34c52ce16f81f1d308a571df7784932cc7491d1e94be2ee93374b",
+                "sha256:01f799def9b96a8ec1ef6b9c1bbaf2bbc859b87545efbecc4a78faea13d0e3a0",
+                "sha256:09d16ae7a13cff43660155383a2372b4aa09109c7127aa3f24c3cf99b891c330",
+                "sha256:14e7e2c5f5fca67e9a6d5f753d21f138398cad2b1159913ec9e9a67745f09ba3",
+                "sha256:167e4793dc987f77fd476862d32fa404d42b71f6a85d3b38cbce711dba5e6b68",
+                "sha256:1807054aa7b61ad8d8103b3b30c9764de2e9d0c0978e9d3fc337e4e74bf25faa",
+                "sha256:1f83e9c21cd5275991076b2ba1cd35418af3504667affb4745b48937e214bafe",
+                "sha256:21b1106bff6ece8cb203ef45b4f5778d7226c941c83aaaa1e1f0f4f32cc148cd",
+                "sha256:22626dca56fd7f55a0733e604f1027277eb0f4f3d95ff28f15d27ac25a45f71b",
+                "sha256:23f96134a3aa24cc50614920cc087e22f87439053d886e474638c68c8d15dc80",
+                "sha256:2498762814dd7dd2a1d0248eda2afbc3dd9c11537bc8200a4b21789b6df6cd38",
+                "sha256:28c659878f684365d53cf59dc9a1929ea2eecd7ac65da762be8b1ba193f7e84f",
+                "sha256:2eca15d6b947cfff51ed76b2d60fd172c6ecd418ddab1c5126032d27f74bc350",
+                "sha256:354d9fc6b1e44750e2a67b4b108841f5f5ea08853453ecbf44c81fdc2e0d50bd",
+                "sha256:36a76a7527df8583112b24adc01748cd51a2d14e905b337a6fefa8b96fc708fb",
+                "sha256:3a0a4ca02752ced5f37498827e49c414d694ad7cf451ee850e3ff160f2bee9d3",
+                "sha256:3a71dbd792cc7a3d772ef8cd08d3048593f13d6f40a11f3427c000cf0a5b36a0",
+                "sha256:3a88254881e8a8c4784ecc9cb2249ff757fd94b911d5df9a5984961b96113fff",
+                "sha256:47045ed35481e857918ae78b54891fac0c1d197f22c95778e66302668309336c",
+                "sha256:4775a574e9d84e0212f5b18886cace049a42e13e12009bb0491562a48bb2b758",
+                "sha256:493da1f8b1bb8a623c16552fb4a1e164c0200447eb83d3f68b44315ead3f9036",
+                "sha256:4b847029e2d5e11fd536c9ac3136ddc3f54bc9488a75ef7d040a3900406a91eb",
+                "sha256:59d7d92cee84a547d91267f0fea381c363121d70fe90b12cd88241bd9b0e1763",
+                "sha256:5a0898a640559dec00f3614ffb11d97a2666ee9a2a6bad1259c9facd01a1d4d9",
+                "sha256:5a9a1889cc01ed2ed5f34574c90745fab1dd06ec2eee663e8ebeefe363e8efd7",
+                "sha256:5b835b86bd5a1bdbe257d610eecab07bf685b1af2a7563093e0e69180c1d4af1",
+                "sha256:5f24ca7953f2643d59a9c87d6e272d8adddd4a53bb62b9208f36db408d7aafc7",
+                "sha256:61e1a064906ccba038aa3c4a5a82f6199749efbbb3cef0804ae5c37f550eded0",
+                "sha256:65bf3eb34721bf18b5a021a1ad7aa05947a1767d1aa272b725728014475ea7d5",
+                "sha256:6807bcee549a8cb2f38f73f469703a1d8d5d990815c3004f21ddb68a567385ce",
+                "sha256:68aeefac31c1f73949662ba8affaf9950b9938b712fb9d428fa2a07e40ee57f8",
+                "sha256:6915682f9a9bc4cf2908e83caf5895a685da1fbd20b6d485dafb8e218a338279",
+                "sha256:6d9810d4f697d58fd66039ab959e6d37e63ab377008ef1d63904df25956c7db0",
+                "sha256:729d5e96566f44fccac6c4447ec2332636b4fe273f03da128fff8d5559782b06",
+                "sha256:748df39ed634851350efa87690c2237a678ed794fe9ede3f0d79f071ee042561",
+                "sha256:763a73ab377390e2af26042f685a26787c402390f682443727b847e9496e4a2a",
+                "sha256:8323a43bd9c91f62bb7d4be74cc9ff10090e7ef820e27bfe8815c57e68261311",
+                "sha256:8529b07b49b2d89d6917cfa157d3ea1dfb4d319d51e23030664a827fe5fd2131",
+                "sha256:87fa943e8bbe40c8c1ba4086971a6fefbf75e9991217c55ed1bcb2f1985bd3d4",
+                "sha256:88236b90dda77f0394f878324cfbae05ae6fde8a84d548cfe73a75278d760291",
+                "sha256:891c353e95bb11abb548ca95c8b98050f3620a7378332eb90d6acdef35b401d4",
+                "sha256:89ba3d548ee1e6291a20f3c7380c92f71e358ce8b9e48161401e087e0bc740f8",
+                "sha256:8c6be72eac3c14baa473620e04f74186c5d8f45d80f8f2b4eda6e1d18af808e8",
+                "sha256:9a242871b3d8eecc56d350e5e03ea1854de47b17f040446da0e47dc3e0b9ad4d",
+                "sha256:9a3ff5fb015f6feb78340143584d9f8a0b91b6293d6b5cf4295b3e95d179b88c",
+                "sha256:9a5a544861b21e0e7575b6023adebe7a8c6321127bb1d238eb40d99803a0e8bd",
+                "sha256:9d57677238a0c5411c76097b8b93bdebb02eb845814c90f0b01727527a179e4d",
+                "sha256:9d8c68c4145041b4eeae96239802cfdfd9ef927754a5be3f50505f09f309d8c6",
+                "sha256:9d9fcd06c952efa4b6b95f3d788a819b7f33d11bea377be6b8980c95e7d10775",
+                "sha256:a0057b5435a65b933cbf5d859cd4956624df37b8bf0917c71756e4b3d9958b9e",
+                "sha256:a65bffd24409454b889af33b6c49d0d9bcd1a219b972fba975ac935f17bdf627",
+                "sha256:b0ed6ad6c9640671689c2dbe6244680fe8b897c08fd1fab2228429b66c518e5e",
+                "sha256:b21650fa6907e523869e0396c5bd591cc326e5c1dd594dcdccac089561cacfb8",
+                "sha256:b3f7e671fb19734c872566e57ce7fc235fa953d7c181bb4ef138e17d607dc8a1",
+                "sha256:b77159d9862374da213f741af0c361720200ab7ad21b9f12556e0eb95912cd48",
+                "sha256:bb36fbb48b22985d13a6b496ea5fb9bb2a076fea943831643836c9f6febbcfdc",
+                "sha256:d066ffc5ed0be00cd0352c95800a519cf9e4b5dd34a028d301bdc7177c72daf3",
+                "sha256:d332eecf307fca852d02b63f35a7872de32d5ba8b4ec32da82f45df986b39ff6",
+                "sha256:d808a5a5411982a09fef6b49aac62986274ab050e9d3e9817ad65b2791ed1425",
+                "sha256:d9bdfa74d369256e4218000a629978590fd7cb6cf6893251dad13d051090436d",
+                "sha256:db6a0ddc1282ceb9032e41853e659c9b638789be38e5b8ad7498caac00231c23",
+                "sha256:debaf04f813ada978d7d16c7dfa16f3c9c2ec9adf4656efdc4defdf841fc2f0c",
+                "sha256:f0408e2dbad9e82b4c960274214af533f856a199c9274bd4aff55d4634dedc33",
+                "sha256:f2f3bc7cd9c9fcd39143f11342eb5963317bd54ecc98e3650ca22704b69d9653"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.14.0"
         },
         "zope.event": {
             "hashes": [

--- a/api/catalog/api/utils/throttle.py
+++ b/api/catalog/api/utils/throttle.py
@@ -8,7 +8,7 @@ from rest_framework.throttling import SimpleRateThrottle
 
 log = logging.getLogger(__name__)
 
-class ThrottleExemption:
+class ThrottleExemption(abc.ABC):
     """
     Abstract class describing a given throttle exemption.
 

--- a/api/catalog/api/utils/throttle.py
+++ b/api/catalog/api/utils/throttle.py
@@ -82,6 +82,9 @@ class ApiKeyExemption(ThrottleExemption):
         being rate-limited.
         """
         client_id, _, _ = get_token_info(str(self.request.auth))
+        if not client_id:
+            return False
+
         redis = get_redis_connection("default")
         return redis.sismember(self.redis_set_name, client_id)
 

--- a/api/catalog/api/utils/throttle.py
+++ b/api/catalog/api/utils/throttle.py
@@ -8,6 +8,7 @@ from rest_framework.throttling import SimpleRateThrottle
 
 log = logging.getLogger(__name__)
 
+
 class ThrottleExemption(abc.ABC):
     """
     Abstract class describing a given throttle exemption.

--- a/api/catalog/api/utils/throttle.py
+++ b/api/catalog/api/utils/throttle.py
@@ -1,3 +1,4 @@
+import abc
 import logging
 
 from catalog.api.utils.oauth2_helper import get_token_info
@@ -8,12 +9,54 @@ from rest_framework.throttling import SimpleRateThrottle
 log = logging.getLogger(__name__)
 
 
-def _from_internal_network(ip):
-    redis = get_redis_connection("default")
-    return redis.sismember("ip-whitelist", ip)
+class ThrottleExemption:
+    def __init__(self, throttle_class, request):
+        self.throttle_class = throttle_class
+        self.request = request
+
+    @abc.abstractmethod
+    def is_exempt(self) -> bool:
+        ...
 
 
-class AnonRateThrottle(SimpleRateThrottle):
+class ExemptionAwareThrottle(SimpleRateThrottle):
+    """
+    An throttle exemption aware base throttle.
+
+    Classes in ``exemption_classes`` are evaluated for each
+    request. If any of them detect an exempted request then
+    the request will not be throttled.
+    """
+
+    exemption_classes = []
+
+    def allow_request(self, request, view):
+        for exemption_class in self.exemption_classes:
+            if exemption_class(self, request).is_exempt():
+                return True
+
+        return super().allow_request(request, view)
+
+
+class InternalNetworkExemption(ThrottleExemption):
+    redis_set_name = "ip-whitelist"
+
+    def is_exempt(self):
+        ip = self.throttle_class.get_ident(self.request)
+        redis = get_redis_connection("default", write=False)
+        return redis.sismember(self.redis_set_name, ip)
+
+
+class ApiKeyExemption(ThrottleExemption):
+    redis_set_name = "client-id-allowlist"
+
+    def is_exempt(self):
+        client_id, _, _ = get_token_info(str(self.request.auth))
+        redis = get_redis_connection("default")
+        return redis.sismember(self.redis_set_name, client_id)
+
+
+class AnonRateThrottle(ExemptionAwareThrottle):
     """
     Limits the rate of API calls that may be made by a anonymous users.
 
@@ -21,10 +64,9 @@ class AnonRateThrottle(SimpleRateThrottle):
     """
 
     scope = "anon"
+    exemption_classes = [InternalNetworkExemption, ApiKeyExemption]
 
     def get_cache_key(self, request, view):
-        if _from_internal_network(self.get_ident(request)):
-            return None
         # Do not throttle requests with a valid access token.
         if request.auth:
             client_id, _, verified = get_token_info(str(request.auth))
@@ -61,7 +103,7 @@ class OnePerSecond(AnonRateThrottle):
     rate = "1/second"
 
 
-class OAuth2IdThrottleRate(SimpleRateThrottle):
+class OAuth2IdThrottleRate(ExemptionAwareThrottle):
     """
     Limits the rate of API calls that may be made by a given user's Oauth2
     client ID. Can be configured to apply to either standard or enhanced
@@ -70,10 +112,9 @@ class OAuth2IdThrottleRate(SimpleRateThrottle):
 
     scope = "oauth2_client_credentials"
     applies_to_rate_limit_model = "standard"
+    exemption_classes = [InternalNetworkExemption, ApiKeyExemption]
 
     def get_cache_key(self, request, view):
-        if _from_internal_network(self.get_ident(request)):
-            return None
         # Find the client ID associated with the access token.
         auth = str(request.auth)
         client_id, rate_limit_model, verified = get_token_info(auth)

--- a/api/test/factory/faker.py
+++ b/api/test/factory/faker.py
@@ -3,6 +3,11 @@ from faker.providers import BaseProvider
 from faker.utils.distribution import choices_distribution
 
 
+class ChoiceProvider(BaseProvider):
+    def random_choice_field(self, choices):
+        return self.random_element(elements=[choice[0] for choice in choices])
+
+
 class WaveformProvider(BaseProvider):
     _float_space = [x / 100.0 for x in range(101)] * 20
 
@@ -14,4 +19,5 @@ class WaveformProvider(BaseProvider):
         return WaveformProvider.generate_waveform()
 
 
+Faker.add_provider(ChoiceProvider)
 Faker.add_provider(WaveformProvider)

--- a/api/test/factory/models/oauth2.py
+++ b/api/test/factory/models/oauth2.py
@@ -1,0 +1,23 @@
+import factory
+from factory.django import DjangoModelFactory
+from oauth2_provider.models import AccessToken
+from datetime import datetime
+from catalog.api.models.oauth import ThrottledApplication
+from test.factory.faker import Faker
+
+
+class ThrottledApplicationFactory(DjangoModelFactory):
+    class Meta:
+        model = ThrottledApplication
+    
+    client_type = Faker("random_choice_field", choices=ThrottledApplication.CLIENT_TYPES)
+    authorization_grant_type = Faker("random_choice_field", choices=ThrottledApplication.GRANT_TYPES)
+
+
+class AccessTokenFactory(DjangoModelFactory):
+    class Meta:
+        model = AccessToken
+
+    token = Faker("uuid4")
+    expires = Faker("date_time_between", start_date="+1y", end_date="+2y")
+    application = factory.SubFactory(ThrottledApplicationFactory)

--- a/api/test/factory/models/oauth2.py
+++ b/api/test/factory/models/oauth2.py
@@ -1,17 +1,21 @@
+from test.factory.faker import Faker
+
 import factory
+from catalog.api.models.oauth import ThrottledApplication
 from factory.django import DjangoModelFactory
 from oauth2_provider.models import AccessToken
-from datetime import datetime
-from catalog.api.models.oauth import ThrottledApplication
-from test.factory.faker import Faker
 
 
 class ThrottledApplicationFactory(DjangoModelFactory):
     class Meta:
         model = ThrottledApplication
-    
-    client_type = Faker("random_choice_field", choices=ThrottledApplication.CLIENT_TYPES)
-    authorization_grant_type = Faker("random_choice_field", choices=ThrottledApplication.GRANT_TYPES)
+
+    client_type = Faker(
+        "random_choice_field", choices=ThrottledApplication.CLIENT_TYPES
+    )
+    authorization_grant_type = Faker(
+        "random_choice_field", choices=ThrottledApplication.GRANT_TYPES
+    )
 
 
 class AccessTokenFactory(DjangoModelFactory):

--- a/api/test/run_test.sh
+++ b/api/test/run_test.sh
@@ -19,7 +19,7 @@ if [[ $succeeded -eq 0 ]]; then
 	printf "${green}:-) All tests passed${endcol}\n"
 else
     printf "Full system logs:\n"
-    # docker-compose logs
+    docker-compose logs
 	printf "${red}:'( Some tests did not pass${endcol}\n"
 fi
 exit $succeeded

--- a/api/test/run_test.sh
+++ b/api/test/run_test.sh
@@ -19,7 +19,7 @@ if [[ $succeeded -eq 0 ]]; then
 	printf "${green}:-) All tests passed${endcol}\n"
 else
     printf "Full system logs:\n"
-    docker-compose logs
+    # docker-compose logs
 	printf "${red}:'( Some tests did not pass${endcol}\n"
 fi
 exit $succeeded

--- a/api/test/unit/utils/throttle_test.py
+++ b/api/test/unit/utils/throttle_test.py
@@ -1,0 +1,168 @@
+from unittest import mock
+import pytest
+from fakeredis import FakeRedis
+from django.http import HttpRequest
+from rest_framework.test import APIRequestFactory, force_authenticate
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.request import Request
+from catalog.api.utils.throttle import ThrottleExemption, ExemptionAwareThrottle, InternalNetworkExemption, ApiKeyExemption
+from catalog.api.utils.oauth2_helper import get_token_info
+from test.factory.models.oauth2 import AccessTokenFactory
+
+
+class HardThrottle(ExemptionAwareThrottle):
+    """
+    A test throttle that denies all requests.
+
+    This is helpful for testing whether the exemptions
+    are working.
+    """
+    rate = "0/second"
+    scope = "test"
+
+    def get_cache_key(self, request, view):
+        return {
+            "scope": self.scope,
+            "ident": self.get_ident(request),
+        }
+
+
+class MockInternalNetworkExemptThrottle(HardThrottle):
+    exemption_classes = (InternalNetworkExemption,)
+
+
+class MockApiKeyExemptThrottle(HardThrottle):
+    exemption_classes = (ApiKeyExemption,)
+
+
+class FooRouteExemption(ThrottleExemption):
+    def is_exempt(self):
+        return self.request.path.startswith("/foo")
+
+
+class MockMultipleExemptionThrottle(HardThrottle):
+    exemption_classes = (InternalNetworkExemption, ApiKeyExemption, FooRouteExemption)
+
+
+
+def get_throttled_view(throttle_class):
+    class MockView(APIView):
+        throttle_classes = (throttle_class,)
+
+        def get(self, request):
+            return Response("foo")
+
+    return MockView().as_view()
+
+
+@pytest.fixture(autouse=True)
+def redis(monkeypatch) -> FakeRedis:
+    fake_redis = FakeRedis()
+    def get_redis_connection(*args, **kwargs):
+        return fake_redis
+
+    monkeypatch.setattr('catalog.api.utils.throttle.get_redis_connection', get_redis_connection)
+
+    yield fake_redis
+    fake_redis.client().close()
+
+
+@pytest.fixture
+def request_factory() -> APIRequestFactory():
+    request_factory = APIRequestFactory(
+        defaults={
+            "REMOTE_ADDR": "192.0.2.1"
+        }
+    )
+
+    return request_factory
+
+
+@pytest.fixture
+def access_token():
+    return AccessTokenFactory.create()
+
+
+@pytest.fixture
+def authed_request(access_token, request_factory):
+    request = request_factory.get('/')
+
+    force_authenticate(request, token=access_token.token)
+
+    return request
+
+
+def assert_view_consistent_status_code(view, request, expected_status, times=4):
+    for _ in range(times):
+        assert view(request).status_code == expected_status
+
+
+def assert_throttles(view, request, times=4):
+    assert_view_consistent_status_code(view, request, expected_status=429)
+
+
+def assert_does_not_throttle(view, request, times=4):
+    assert_view_consistent_status_code(view, request, expected_status=200)
+
+
+def test_hard_throttle_denies_requests(request_factory):
+    view = get_throttled_view(HardThrottle)
+    request = request_factory.get('/')
+    assert_throttles(view, request)
+
+
+def test_internal_network_exemption_passes_when_ip_in_allowlist(redis, request_factory):
+    view = get_throttled_view(MockInternalNetworkExemptThrottle)
+    request = request_factory.get('/')
+    redis.sadd(InternalNetworkExemption.redis_set_name, request.META["REMOTE_ADDR"])
+    assert_does_not_throttle(view, request)
+
+
+def test_internal_network_exemption_throttles_when_ip_not_in_allowlist(redis, request_factory):
+    view = get_throttled_view(MockInternalNetworkExemptThrottle)
+    request = request_factory.get('/')
+    assert not redis.sismember(InternalNetworkExemption.redis_set_name, request.META["REMOTE_ADDR"])
+    assert_throttles(view, request)
+
+
+@pytest.mark.django_db
+def test_api_key_exemption_passes_when_token_in_allowlist(redis, access_token, authed_request):
+    view = get_throttled_view(MockApiKeyExemptThrottle)
+    client_id, _, _ = get_token_info(access_token.token)
+    redis.sadd(ApiKeyExemption.redis_set_name, client_id)
+    assert_does_not_throttle(view, authed_request)
+
+
+@pytest.mark.django_db
+def test_api_key_exemption_throttles_when_token_not_in_allowlist(redis, access_token, authed_request):
+    view = get_throttled_view(MockApiKeyExemptThrottle)
+    client_id, _, _ = get_token_info(access_token.token)
+    assert not redis.sismember(ApiKeyExemption.redis_set_name, client_id)
+    assert_throttles(view, authed_request)
+
+
+@pytest.mark.django_db
+def test_multiple_exemptions_allows_if_one_passes_api_key(redis, access_token, authed_request):
+    view = get_throttled_view(MockMultipleExemptionThrottle)
+    client_id, _, _ = get_token_info(access_token.token)
+    redis.sadd(ApiKeyExemption.redis_set_name, client_id)
+    assert not redis.sismember(InternalNetworkExemption.redis_set_name, authed_request.META["REMOTE_ADDR"])
+    assert_does_not_throttle(view, authed_request)
+
+@pytest.mark.django_db
+def test_multiple_exemptions_allows_if_one_passes_internal_network(redis, access_token, authed_request):
+    view = get_throttled_view(MockMultipleExemptionThrottle)
+    client_id, _, _ = get_token_info(access_token.token)
+    redis.sadd(InternalNetworkExemption.redis_set_name, authed_request.META["REMOTE_ADDR"])
+    assert not redis.sismember(ApiKeyExemption.redis_set_name, client_id)
+    assert_does_not_throttle(view, authed_request)
+
+
+@pytest.mark.django_db
+def test_multiple_exemptions_throttles_if_none_pass(redis, access_token, authed_request):
+    view = get_throttled_view(MockMultipleExemptionThrottle)
+    client_id, _, _ = get_token_info(access_token.token)
+    assert not redis.sismember(InternalNetworkExemption.redis_set_name, authed_request.META["REMOTE_ADDR"])
+    assert not redis.sismember(ApiKeyExemption.redis_set_name, client_id)
+    assert_throttles(view, authed_request)

--- a/api/test/unit/utils/throttle_test.py
+++ b/api/test/unit/utils/throttle_test.py
@@ -143,6 +143,13 @@ def test_api_key_exemption_throttles_when_token_not_in_allowlist(redis, access_t
 
 
 @pytest.mark.django_db
+def test_api_key_exemption_throttles_with_unauthed_request(request_factory):
+    request = request_factory.get("/")
+    view = get_throttled_view(MockApiKeyExemptThrottle)
+    assert_throttles(view, request)
+
+
+@pytest.mark.django_db
 def test_multiple_exemptions_allows_if_one_passes_api_key(redis, access_token, authed_request):
     view = get_throttled_view(MockMultipleExemptionThrottle)
     client_id, _, _ = get_token_info(access_token.token)

--- a/api/test/unit/utils/throttle_test.py
+++ b/api/test/unit/utils/throttle_test.py
@@ -1,14 +1,17 @@
-from unittest import mock
+from test.factory.models.oauth2 import AccessTokenFactory
+
 import pytest
+from catalog.api.utils.oauth2_helper import get_token_info
+from catalog.api.utils.throttle import (
+    ApiKeyExemption,
+    ExemptionAwareThrottle,
+    InternalNetworkExemption,
+    ThrottleExemption,
+)
 from fakeredis import FakeRedis
-from django.http import HttpRequest
+from rest_framework.response import Response
 from rest_framework.test import APIRequestFactory, force_authenticate
 from rest_framework.views import APIView
-from rest_framework.response import Response
-from rest_framework.request import Request
-from catalog.api.utils.throttle import ThrottleExemption, ExemptionAwareThrottle, InternalNetworkExemption, ApiKeyExemption
-from catalog.api.utils.oauth2_helper import get_token_info
-from test.factory.models.oauth2 import AccessTokenFactory
 
 
 class HardThrottle(ExemptionAwareThrottle):
@@ -18,6 +21,7 @@ class HardThrottle(ExemptionAwareThrottle):
     This is helpful for testing whether the exemptions
     are working.
     """
+
     rate = "0/second"
     scope = "test"
 
@@ -45,7 +49,6 @@ class MockMultipleExemptionThrottle(HardThrottle):
     exemption_classes = (InternalNetworkExemption, ApiKeyExemption, FooRouteExemption)
 
 
-
 def get_throttled_view(throttle_class):
     class MockView(APIView):
         throttle_classes = (throttle_class,)
@@ -59,10 +62,13 @@ def get_throttled_view(throttle_class):
 @pytest.fixture(autouse=True)
 def redis(monkeypatch) -> FakeRedis:
     fake_redis = FakeRedis()
+
     def get_redis_connection(*args, **kwargs):
         return fake_redis
 
-    monkeypatch.setattr('catalog.api.utils.throttle.get_redis_connection', get_redis_connection)
+    monkeypatch.setattr(
+        "catalog.api.utils.throttle.get_redis_connection", get_redis_connection
+    )
 
     yield fake_redis
     fake_redis.client().close()
@@ -70,11 +76,7 @@ def redis(monkeypatch) -> FakeRedis:
 
 @pytest.fixture
 def request_factory() -> APIRequestFactory():
-    request_factory = APIRequestFactory(
-        defaults={
-            "REMOTE_ADDR": "192.0.2.1"
-        }
-    )
+    request_factory = APIRequestFactory(defaults={"REMOTE_ADDR": "192.0.2.1"})
 
     return request_factory
 
@@ -86,7 +88,7 @@ def access_token():
 
 @pytest.fixture
 def authed_request(access_token, request_factory):
-    request = request_factory.get('/')
+    request = request_factory.get("/")
 
     force_authenticate(request, token=access_token.token)
 
@@ -99,35 +101,41 @@ def assert_view_consistent_status_code(view, request, expected_status, times=4):
 
 
 def assert_throttles(view, request, times=4):
-    assert_view_consistent_status_code(view, request, expected_status=429)
+    assert_view_consistent_status_code(view, request, expected_status=429, times=times)
 
 
 def assert_does_not_throttle(view, request, times=4):
-    assert_view_consistent_status_code(view, request, expected_status=200)
+    assert_view_consistent_status_code(view, request, expected_status=200, times=times)
 
 
 def test_hard_throttle_denies_requests(request_factory):
     view = get_throttled_view(HardThrottle)
-    request = request_factory.get('/')
+    request = request_factory.get("/")
     assert_throttles(view, request)
 
 
 def test_internal_network_exemption_passes_when_ip_in_allowlist(redis, request_factory):
     view = get_throttled_view(MockInternalNetworkExemptThrottle)
-    request = request_factory.get('/')
+    request = request_factory.get("/")
     redis.sadd(InternalNetworkExemption.redis_set_name, request.META["REMOTE_ADDR"])
     assert_does_not_throttle(view, request)
 
 
-def test_internal_network_exemption_throttles_when_ip_not_in_allowlist(redis, request_factory):
+def test_internal_network_exemption_throttles_when_ip_not_in_allowlist(
+    redis, request_factory
+):
     view = get_throttled_view(MockInternalNetworkExemptThrottle)
-    request = request_factory.get('/')
-    assert not redis.sismember(InternalNetworkExemption.redis_set_name, request.META["REMOTE_ADDR"])
+    request = request_factory.get("/")
+    assert not redis.sismember(
+        InternalNetworkExemption.redis_set_name, request.META["REMOTE_ADDR"]
+    )
     assert_throttles(view, request)
 
 
 @pytest.mark.django_db
-def test_api_key_exemption_passes_when_token_in_allowlist(redis, access_token, authed_request):
+def test_api_key_exemption_passes_when_token_in_allowlist(
+    redis, access_token, authed_request
+):
     view = get_throttled_view(MockApiKeyExemptThrottle)
     client_id, _, _ = get_token_info(access_token.token)
     redis.sadd(ApiKeyExemption.redis_set_name, client_id)
@@ -135,7 +143,9 @@ def test_api_key_exemption_passes_when_token_in_allowlist(redis, access_token, a
 
 
 @pytest.mark.django_db
-def test_api_key_exemption_throttles_when_token_not_in_allowlist(redis, access_token, authed_request):
+def test_api_key_exemption_throttles_when_token_not_in_allowlist(
+    redis, access_token, authed_request
+):
     view = get_throttled_view(MockApiKeyExemptThrottle)
     client_id, _, _ = get_token_info(access_token.token)
     assert not redis.sismember(ApiKeyExemption.redis_set_name, client_id)
@@ -150,26 +160,39 @@ def test_api_key_exemption_throttles_with_unauthed_request(request_factory):
 
 
 @pytest.mark.django_db
-def test_multiple_exemptions_allows_if_one_passes_api_key(redis, access_token, authed_request):
+def test_multiple_exemptions_allows_if_one_passes_api_key(
+    redis, access_token, authed_request
+):
     view = get_throttled_view(MockMultipleExemptionThrottle)
     client_id, _, _ = get_token_info(access_token.token)
     redis.sadd(ApiKeyExemption.redis_set_name, client_id)
-    assert not redis.sismember(InternalNetworkExemption.redis_set_name, authed_request.META["REMOTE_ADDR"])
+    assert not redis.sismember(
+        InternalNetworkExemption.redis_set_name, authed_request.META["REMOTE_ADDR"]
+    )
     assert_does_not_throttle(view, authed_request)
 
+
 @pytest.mark.django_db
-def test_multiple_exemptions_allows_if_one_passes_internal_network(redis, access_token, authed_request):
+def test_multiple_exemptions_allows_if_one_passes_internal_network(
+    redis, access_token, authed_request
+):
     view = get_throttled_view(MockMultipleExemptionThrottle)
     client_id, _, _ = get_token_info(access_token.token)
-    redis.sadd(InternalNetworkExemption.redis_set_name, authed_request.META["REMOTE_ADDR"])
+    redis.sadd(
+        InternalNetworkExemption.redis_set_name, authed_request.META["REMOTE_ADDR"]
+    )
     assert not redis.sismember(ApiKeyExemption.redis_set_name, client_id)
     assert_does_not_throttle(view, authed_request)
 
 
 @pytest.mark.django_db
-def test_multiple_exemptions_throttles_if_none_pass(redis, access_token, authed_request):
+def test_multiple_exemptions_throttles_if_none_pass(
+    redis, access_token, authed_request
+):
     view = get_throttled_view(MockMultipleExemptionThrottle)
     client_id, _, _ = get_token_info(access_token.token)
-    assert not redis.sismember(InternalNetworkExemption.redis_set_name, authed_request.META["REMOTE_ADDR"])
+    assert not redis.sismember(
+        InternalNetworkExemption.redis_set_name, authed_request.META["REMOTE_ADDR"]
+    )
     assert not redis.sismember(ApiKeyExemption.redis_set_name, client_id)
     assert_throttles(view, authed_request)


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #565 by @zackkrida 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Adds the ability to easily define exemptions for throttle classes via a general DRF/Django OOP inspired approach.

The idea is that each exemption is defined as its own class which implements the `is_exempt` method which returns a boolean: true when exempt and false otherwise. If any exemption class declares the request as exempt from throttling, then the throttle's `allow_request` logic is short circuited and the request is allowed.

I've added comprehensive unit tests for this. I tried to cover every possible configuration and request situation with redundant checks against the pre-existing state before checking the requests.

The tests are roughly modeled after DRF's own tests for the base throttling classes: https://github.com/encode/django-rest-framework/blob/master/tests/test_throttling.py.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
As I mentioned, the unit tests should cover the code 100%.

We can also rely on the integration tests, they should all continue to pass without exception.

Smoke testing the API by running it locally and checking a few requests wouldn't hurt either. If you really feel like it, modifying the local running redis instance to add localhost IP or an API key to the client id allow list would also be good.

For example, on my computer, I exec'd into the redis container using:

```bash
docker-compose exec cache redis-cli
```

Then ran:

```
SADD 'ip-whitelist' '172.20.0.1'
```

And verified that I would not get rate limited.

Now run:

```
SREM 'ip-whitelist' '172.20.0.1'
```

and confirm that you _do_ get throttled.

I think you could do the same using the `AccessTokenFactory` in `just ipython` but there's some extra configuration you need to do to get the locally running app configured for oauth I guess.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
