### PR TITLE
Remove `query_serializer` for reporting endpoints

### DIFF
--- a/api/catalog/api/docs/audio_docs.py
+++ b/api/catalog/api/docs/audio_docs.py
@@ -203,7 +203,6 @@ contains mature or sensitive content and others.
     swagger_setup = {
         "operation_id": "audio_report",
         "operation_description": desc,
-        "query_serializer": AudioReportSerializer,
         "responses": responses,
         "code_examples": code_examples,
     }

--- a/api/catalog/api/docs/image_docs.py
+++ b/api/catalog/api/docs/image_docs.py
@@ -199,7 +199,6 @@ contains mature or sensitive content and others.
     swagger_setup = {
         "operation_id": "image_report",
         "operation_description": desc,
-        "query_serializer": ImageReportSerializer,
         "responses": responses,
         "code_examples": code_examples,
     }


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
The reporting endpoints for audio and image had the `query_serializer` set on the Swagger operation. This caused the schema of the data sent in the POST body to be shown as the query parameters.

Screenshot on `main`:
<img width="531" alt="Screenshot 2022-03-20 at 11 27 16 AM" src="https://user-images.githubusercontent.com/16580576/159152636-b1d98217-c948-4e12-8648-89051de19ec0.png">

By removing the `query_serializer`, this duplication is gone and the information appears in the correct location.

Screenshot from PR:
<img width="531" alt="Screenshot 2022-03-20 at 11 27 42 AM" src="https://user-images.githubusercontent.com/16580576/159152643-f75df8ed-a456-4f40-ae73-6354bb696764.png">

## Testing Instructions
0. Check out the PR and run the services using `just up`.
1. Visit the API docs for the image and audio report endpoints.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
