### PR TITLE
Replace plural `categories` as field name with singular `category`

### DIFF
--- a/api/catalog/api/controllers/search_controller.py
+++ b/api/catalog/api/controllers/search_controller.py
@@ -240,6 +240,7 @@ def search(
     filters = [
         ("extension", None),
         ("category", None),
+        ("categories", "category"),
         ("aspect_ratio", None),
         ("size", None),
         ("source", None),

--- a/api/catalog/api/controllers/search_controller.py
+++ b/api/catalog/api/controllers/search_controller.py
@@ -239,7 +239,7 @@ def search(
     # names are identical.
     filters = [
         ("extension", None),
-        ("categories", None),
+        ("category", None),
         ("aspect_ratio", None),
         ("size", None),
         ("source", None),

--- a/api/catalog/api/serializers/audio_serializers.py
+++ b/api/catalog/api/serializers/audio_serializers.py
@@ -52,7 +52,7 @@ class AudioSearchRequestSerializer(
     fields_names = [
         *MediaSearchRequestSerializer.fields_names,
         *AudioSearchRequestSourceSerializer.field_names,
-        "categories",
+        "category",
         "duration",
     ]
     """
@@ -60,8 +60,8 @@ class AudioSearchRequestSerializer(
     used to generate Swagger documentation.
     """
 
-    categories = serializers.CharField(
-        label="categories",
+    category = serializers.CharField(
+        label="category",
         help_text="A comma separated list of categories; available categories "
         "include `music`, `sound_effect`, `podcast`, `audiobook`, "
         "and `news`.",

--- a/api/catalog/api/serializers/image_serializers.py
+++ b/api/catalog/api/serializers/image_serializers.py
@@ -26,7 +26,7 @@ class ImageSearchRequestSerializer(
     fields_names = [
         *MediaSearchRequestSerializer.fields_names,
         *ImageSearchRequestSourceSerializer.field_names,
-        "categories",
+        "category",
         "aspect_ratio",
         "size",
     ]
@@ -36,8 +36,8 @@ class ImageSearchRequestSerializer(
     """
 
     # Ref: ingestion_server/ingestion_server/categorize.py#Category
-    categories = serializers.CharField(
-        label="categories",
+    category = serializers.CharField(
+        label="category",
         help_text="A comma separated list of categories; available categories "
         "include `illustration`, `photograph`, and "
         "`digitized_artwork`.",

--- a/api/catalog/api/serializers/media_serializers.py
+++ b/api/catalog/api/serializers/media_serializers.py
@@ -152,6 +152,7 @@ class MediaSearchRequestSerializer(serializers.Serializer):
         DeprecatedParam("lt", "license_type"),
         DeprecatedParam("pagesize", "page_size"),
         DeprecatedParam("provider", "source"),
+        DeprecatedParam("categories", "category"),
     ]
     fields_names = [
         "q",

--- a/api/catalog/api/serializers/media_serializers.py
+++ b/api/catalog/api/serializers/media_serializers.py
@@ -152,7 +152,6 @@ class MediaSearchRequestSerializer(serializers.Serializer):
         DeprecatedParam("lt", "license_type"),
         DeprecatedParam("pagesize", "page_size"),
         DeprecatedParam("provider", "source"),
-        DeprecatedParam("categories", "category"),
     ]
     fields_names = [
         "q",

--- a/api/test/audio_integration_test.py
+++ b/api/test/audio_integration_test.py
@@ -10,6 +10,7 @@ from test.media_integration import (
     report,
     search,
     search_all_excluded,
+    search_by_category,
     search_consistency,
     search_quotes,
     search_source_and_excluded,
@@ -32,6 +33,11 @@ def audio_fixture():
 
 def test_search(audio_fixture):
     search(audio_fixture)
+
+
+def test_search_category_filtering(audio_fixture):
+    search_by_category("audio", "music", audio_fixture)
+    search_by_category("audio", "pronuntiation", audio_fixture)
 
 
 def test_search_all_excluded():

--- a/api/test/audio_integration_test.py
+++ b/api/test/audio_integration_test.py
@@ -37,7 +37,7 @@ def test_search(audio_fixture):
 
 def test_search_category_filtering(audio_fixture):
     search_by_category("audio", "music", audio_fixture)
-    search_by_category("audio", "pronuntiation", audio_fixture)
+    search_by_category("audio", "pronunciation", audio_fixture)
 
 
 def test_search_all_excluded():

--- a/api/test/media_integration.py
+++ b/api/test/media_integration.py
@@ -14,6 +14,16 @@ def search(fixture):
     assert fixture["result_count"] > 0
 
 
+def search_by_category(media_path, category, fixture):
+    response = requests.get(f"{API_URL}/v1/{media_path}?category={category}")
+    assert response.status_code == 200
+    data = json.loads(response.text)
+    assert data["result_count"] < fixture["result_count"]
+    results = data["results"]
+    # Make sure each result is from the specified category
+    assert all(audio_item["category"] == category for audio_item in results)
+
+
 def search_all_excluded(media_path, excluded_source):
     response = requests.get(
         f"{API_URL}/v1/{media_path}?q=test&excluded_source={','.join(excluded_source)}"


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes [@openverse-frontend#1169](https://github.com/WordPress/openverse-frontend/issues/1169)

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Note: this does not really use category when filtering the search result, hence Draft status. 
But setting category to singular is correct because all other parameters use singular words.
`category` field was using plural and singular forms interchangeably in the codebase. This caused errors when filtering by `category`:
- for audio it always returned 0 results
- for images, it seems to have returned correctly filtered results, but with `category` field sent to the front end being set to `null`.

To ensure that this change doesn't break anyone's code that was using `categories` as an image filter, ~~I added it to the list of deprecated parameters.~~ I removed it from the deprecated parameters, and added a duplicate filter to the search controller to make sure that both parameters work

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run `just up`, `just init`, and try searching for something, filtering it by category.
`http://localhost:8000/v1/audio/?q=look%20back&category=music` should return 1 result

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
