### PR TITLE
Replace plural `categories` as field name with singular `category`

### DIFF
--- a/api/test/audio_integration_test.py
+++ b/api/test/audio_integration_test.py
@@ -10,6 +10,7 @@ from test.media_integration import (
     report,
     search,
     search_all_excluded,
+    search_by_category,
     search_consistency,
     search_quotes,
     search_source_and_excluded,
@@ -32,6 +33,11 @@ def audio_fixture():
 
 def test_search(audio_fixture):
     search(audio_fixture)
+
+
+def test_search_category_filtering(audio_fixture):
+    search_by_category("audio", "music", audio_fixture)
+    search_by_category("audio", "pronuntiation", audio_fixture)
 
 
 def test_search_all_excluded():

--- a/api/test/media_integration.py
+++ b/api/test/media_integration.py
@@ -14,6 +14,16 @@ def search(fixture):
     assert fixture["result_count"] > 0
 
 
+def search_by_category(media_path, category, fixture):
+    response = requests.get(f"{API_URL}/v1/{media_path}?category={category}")
+    assert response.status_code == 200
+    data = json.loads(response.text)
+    assert data["result_count"] < fixture["result_count"]
+    results = data["results"]
+    # Make sure each result is from the specified category
+    assert all(audio_item["category"] == category for audio_item in results)
+
+
 def search_all_excluded(media_path, excluded_source):
     response = requests.get(
         f"{API_URL}/v1/{media_path}?q=test&excluded_source={','.join(excluded_source)}"


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Related to #583 by @obulat

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Add an automated test to complement the fix and cover the bug.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Run the following commands in the `main` branch, note that it fails, and then try on this branch.

```
just up
docker-compose exec web bash
./test/run_test.sh test/audio_integration_test.py
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
