### PR TITLE
Accurately report status of data_refresh when work is distributed

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -144,6 +144,7 @@ jobs:
   push:
     name: Publish Docker images
     runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
     needs:
       - test-ing
       - test-api
@@ -174,14 +175,9 @@ jobs:
         run: |
           docker load --input /tmp/${{ matrix.image }}.tar
           docker tag openverse-${{ matrix.image }} \
-            ghcr.io/wordpress/openverse-${{ matrix.image }}:${{ github.sha }}
-          docker push --all-tags ghcr.io/wordpress/openverse-${{ matrix.image }}
-
-      - name: Tag image `${{ matrix.image }}` - release
-        if: github.event_name == 'release' && github.event.action == 'published'
-        run: |
-          docker tag openverse-${{ matrix.image }} \
             ghcr.io/wordpress/openverse-${{ matrix.image }}:latest
+          docker tag openverse-${{ matrix.image }} \
+            ghcr.io/wordpress/openverse-${{ matrix.image }}:${{ github.sha }}
           docker tag openverse-${{ matrix.image }} \
             ghcr.io/wordpress/openverse-${{ matrix.image }}:${{ github.ref_name }}
           docker push --all-tags ghcr.io/wordpress/openverse-${{ matrix.image }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -144,7 +144,6 @@ jobs:
   push:
     name: Publish Docker images
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
     needs:
       - test-ing
       - test-api
@@ -175,9 +174,14 @@ jobs:
         run: |
           docker load --input /tmp/${{ matrix.image }}.tar
           docker tag openverse-${{ matrix.image }} \
-            ghcr.io/wordpress/openverse-${{ matrix.image }}:latest
-          docker tag openverse-${{ matrix.image }} \
             ghcr.io/wordpress/openverse-${{ matrix.image }}:${{ github.sha }}
+          docker push --all-tags ghcr.io/wordpress/openverse-${{ matrix.image }}
+
+      - name: Tag image `${{ matrix.image }}` - release
+        if: github.event_name == 'release' && github.event.action == 'published'
+        run: |
+          docker tag openverse-${{ matrix.image }} \
+            ghcr.io/wordpress/openverse-${{ matrix.image }}:latest
           docker tag openverse-${{ matrix.image }} \
             ghcr.io/wordpress/openverse-${{ matrix.image }}:${{ github.ref_name }}
           docker push --all-tags ghcr.io/wordpress/openverse-${{ matrix.image }}

--- a/ingestion_server/ingestion_server/api.py
+++ b/ingestion_server/ingestion_server/api.py
@@ -87,6 +87,7 @@ class TaskResource(BaseTaskResource):
         # Inject shared memory
         progress = Value("d", 0.0)
         finish_time = Value("d", 0.0)
+        active_workers = Value("i", int(False)) # Tracks whether the task has any active distributed workers
         task = Task(
             model=model,
             task_type=TaskTypes[action],
@@ -94,10 +95,11 @@ class TaskResource(BaseTaskResource):
             progress=progress,
             task_id=task_id,
             finish_time=finish_time,
+            active_workers=active_workers,
             callback_url=callback_url,
         )
         task.start()
-        task_id = self.tracker.add_task(task, task_id, action, progress, finish_time)
+        task_id = self.tracker.add_task(task, task_id, action, progress, finish_time, active_workers)
         base_url = self._get_base_url(req)
         status_url = f"{base_url}/task/{task_id}"
         # Give the task a moment to start so we can detect immediate failure.
@@ -129,9 +131,11 @@ class TaskStatus(BaseTaskResource):
     def on_get(self, req, resp, task_id):
         """Check the status of a single task."""
         task = self.tracker.id_task[task_id]
-        active = task.is_alive()
 
         percent_completed = self.tracker.id_progress[task_id].value
+        active_workers = bool(self.tracker.id_active_workers[task_id].value)
+        active = task.is_alive() or active_workers
+
         resp.media = {
             "active": active,
             "percent_completed": percent_completed,
@@ -139,7 +143,7 @@ class TaskStatus(BaseTaskResource):
         }
 
 
-class WorkerFinishedResource:
+class WorkerFinishedResource(BaseTaskResource):
     """
     For notifying ingestion server that an indexing worker has finished its
     task.
@@ -147,21 +151,23 @@ class WorkerFinishedResource:
 
     @staticmethod
     def on_post(req, _):
-        target_index = worker_finished(str(req.remote_addr))
-        if target_index:
+        task_data = worker_finished(str(req.remote_addr))
+        if task_data:
             logging.info(
                 "All indexer workers finished! Attempting to promote index "
-                f"{target_index}"
+                f"{task_data['target_index']}"
             )
-            index_type = target_index.split("-")[0]
+            index_type = task_data['target_index'].split("-")[0]
             if index_type not in MEDIA_TYPES:
                 index_type = "image"
             slack.verbose(
                 f"`{index_type}`: Elasticsearch reindex complete | "
                 f"_Next: promote index as primary_"
             )
+            task_id = task_data['task_id']
+            active_workers = tracker.id_active_workers[task_id]
             f = indexer.TableIndexer.go_live
-            p = Process(target=f, args=(target_index, index_type))
+            p = Process(target=f, args=(task_data['target_index'], index_type, active_workers))
             p.start()
 
 
@@ -195,7 +201,7 @@ def create_api(log=True):
     _api.add_route("/", HealthResource())
     _api.add_route("/task", TaskResource(task_tracker))
     _api.add_route("/task/{task_id}", TaskStatus(task_tracker))
-    _api.add_route("/worker_finished", WorkerFinishedResource())
+    _api.add_route("/worker_finished", WorkerFinishedResource(task_tracker))
     _api.add_route("/state", StateResource())
 
     return _api

--- a/ingestion_server/ingestion_server/api.py
+++ b/ingestion_server/ingestion_server/api.py
@@ -164,7 +164,7 @@ class WorkerFinishedResource(BaseTaskResource):
         target_index = task_data.target_index
         active_workers = self.tracker.id_active_workers[task_id]
 
-        # Update progress
+        # Update global task progress based on worker results
         self.tracker.id_progress[task_id] = task_data.percent_successful
 
         if task_data.percent_successful == 100:

--- a/ingestion_server/ingestion_server/api.py
+++ b/ingestion_server/ingestion_server/api.py
@@ -157,9 +157,9 @@ class WorkerFinishedResource(BaseTaskResource):
         task_data = worker_finished(str(req.remote_addr), req.media["error"])
         task_id = task_data["task_id"]
         # Update progress
-        self.tracker.id_progress[task_id] = task_data['percent_completed']
+        self.tracker.id_progress[task_id] = task_data["percent_completed"]
 
-        if task_data['percent_completed'] == 100:
+        if task_data["percent_completed"] == 100:
             logging.info(
                 "All indexer workers finished! Attempting to promote index "
                 f"{task_data['target_index']}"

--- a/ingestion_server/ingestion_server/api.py
+++ b/ingestion_server/ingestion_server/api.py
@@ -154,7 +154,7 @@ class WorkerFinishedResource(BaseTaskResource):
     """
 
     def on_post(self, req, _):
-        task_data = worker_finished(str(req.remote_addr))
+        task_data = worker_finished(str(req.remote_addr), req.media["error"])
         task_id = task_data["task_id"]
         # Update progress
         self.tracker.id_progress[task_id] = task_data['percent_completed']

--- a/ingestion_server/ingestion_server/api.py
+++ b/ingestion_server/ingestion_server/api.py
@@ -179,16 +179,13 @@ class WorkerFinishedResource(BaseTaskResource):
                 f"_Next: promote index as primary_"
             )
             f = indexer.TableIndexer.go_live
-            p = Process(
-                target=f, args=(target_index, index_type, active_workers)
-            )
+            p = Process(target=f, args=(target_index, index_type, active_workers))
             p.start()
         elif task_data.percent_completed == 100:
             # All workers finished, but not all were successful. Mark
             # workers as complete and do not attempt to go live with the new
             # indices.
             active_workers.value = int(False)
-
 
 
 class StateResource:

--- a/ingestion_server/ingestion_server/api.py
+++ b/ingestion_server/ingestion_server/api.py
@@ -134,9 +134,8 @@ class TaskResource(BaseTaskResource):
 class TaskStatus(BaseTaskResource):
     def on_get(self, req, resp, task_id):
         """Check the status of a single task."""
-        try:
-            task = self.tracker.id_task[task_id]
-        except KeyError:
+        task = self.tracker.id_task.get(task_id)
+        if task is None:
             resp.status = falcon.HTTP_404
             resp.media = {"message": f"No task found with id {task_id}"}
             return

--- a/ingestion_server/ingestion_server/api.py
+++ b/ingestion_server/ingestion_server/api.py
@@ -134,7 +134,12 @@ class TaskResource(BaseTaskResource):
 class TaskStatus(BaseTaskResource):
     def on_get(self, req, resp, task_id):
         """Check the status of a single task."""
-        task = self.tracker.id_task[task_id]
+        try:
+            task = self.tracker.id_task[task_id]
+        except KeyError:
+            resp.status = falcon.HTTP_404
+            resp.media = {"message": f"No task found with id {task_id}"}
+            return
 
         percent_completed = self.tracker.id_progress[task_id].value
         active_workers = bool(self.tracker.id_active_workers[task_id].value)

--- a/ingestion_server/ingestion_server/distributed_reindex_scheduler.py
+++ b/ingestion_server/ingestion_server/distributed_reindex_scheduler.py
@@ -24,9 +24,9 @@ from ingestion_server.state import register_indexing_job
 client = boto3.client("ec2", region_name=config("AWS_REGION", default="us-east-1"))
 
 
-def schedule_distributed_index(db_conn, target_index):
+def schedule_distributed_index(db_conn, target_index, task_id):
     workers = _prepare_workers()
-    registered = register_indexing_job(workers, target_index)
+    registered = register_indexing_job(workers, target_index, task_id)
     if registered:
         _assign_work(db_conn, workers, target_index)
 

--- a/ingestion_server/ingestion_server/indexer.py
+++ b/ingestion_server/ingestion_server/indexer.py
@@ -167,13 +167,15 @@ def get_last_item_ids(table):
 
 
 class TableIndexer:
-    def __init__(self, es_instance, tables, progress=None, finish_time=None):
+    def __init__(self, es_instance, tables, task_id=None, progress=None, finish_time=None, active_workers=None):
         self.es = es_instance
         connections.connections.add_connection("default", self.es)
         self.tables_to_watch = tables
         # Optional multiprocessing.Values for examining indexing progress
+        self.task_id = task_id
         self.progress = progress
         self.finish_time = finish_time
+        self.active_workers = active_workers
 
     def _index_table(self, table, dest_idx=None):
         """
@@ -337,7 +339,7 @@ class TableIndexer:
         return delta < max_delta
 
     @staticmethod
-    def go_live(write_index, live_alias):
+    def go_live(write_index, live_alias, active_workers=None):
         """
         Point the live index alias at the index we just created. Delete the
         previous one.
@@ -377,6 +379,9 @@ class TableIndexer:
         else:
             es.indices.put_alias(index=write_index, name=live_alias)
             log.info(f"Created '{live_alias}' index alias pointing to {write_index}")
+        # If there were any active workers for this task, we should mark them complete.
+        if active_workers:
+            active_workers.value = int(False)
         slack.info(
             f"`{write_index}`: ES index promoted - data refresh complete! :tada:"
         )
@@ -411,7 +416,8 @@ class TableIndexer:
             self.es.indices.create(
                 index=destination_index, body=index_settings(model_name)
             )
-            schedule_distributed_index(database_connect(), destination_index)
+            self.active_workers.value = int(True)
+            schedule_distributed_index(database_connect(), destination_index, self.task_id)
         else:
             self._index_table(model_name, dest_idx=destination_index)
             slack.verbose(

--- a/ingestion_server/ingestion_server/indexer.py
+++ b/ingestion_server/ingestion_server/indexer.py
@@ -167,7 +167,15 @@ def get_last_item_ids(table):
 
 
 class TableIndexer:
-    def __init__(self, es_instance, tables, task_id=None, progress=None, finish_time=None, active_workers=None):
+    def __init__(
+        self,
+        es_instance,
+        tables,
+        task_id=None,
+        progress=None,
+        finish_time=None,
+        active_workers=None,
+    ):
         self.es = es_instance
         connections.connections.add_connection("default", self.es)
         self.tables_to_watch = tables
@@ -417,7 +425,9 @@ class TableIndexer:
                 index=destination_index, body=index_settings(model_name)
             )
             self.active_workers.value = int(True)
-            schedule_distributed_index(database_connect(), destination_index, self.task_id)
+            schedule_distributed_index(
+                database_connect(), destination_index, self.task_id
+            )
         else:
             self._index_table(model_name, dest_idx=destination_index)
             slack.verbose(

--- a/ingestion_server/ingestion_server/indexer_worker.py
+++ b/ingestion_server/ingestion_server/indexer_worker.py
@@ -76,13 +76,15 @@ def _execute_indexing_task(target_index, start_id, end_id, notify_url):
 
 
 def _launch_reindex(table, target_index, query, indexer, notify_url):
+    error = False
     try:
         indexer.replicate(table, target_index, query)
     except Exception:
         log.error("Indexing error occurred: ", exc_info=True)
+        error = True
 
     log.info(f"Notifying {notify_url}")
-    requests.post(notify_url)
+    requests.post(notify_url, json={"error": error})
     _self_destruct()
     return
 

--- a/ingestion_server/ingestion_server/indexer_worker.py
+++ b/ingestion_server/ingestion_server/indexer_worker.py
@@ -8,7 +8,7 @@ data has been indexed, notify Ingestion Server and stop the instance.
 
 import logging as log
 import sys
-from multiprocessing import Process, Value
+from multiprocessing import Process
 
 import boto3
 import falcon
@@ -16,6 +16,7 @@ import requests
 from decouple import config
 from psycopg2.sql import SQL, Identifier, Literal
 
+from ingestion_server import slack
 from ingestion_server.constants.media_types import MEDIA_TYPES
 from ingestion_server.indexer import TableIndexer, elasticsearch_connect
 from ingestion_server.queries import get_existence_queries
@@ -82,7 +83,7 @@ def _launch_reindex(table, target_index, query, indexer, notify_url):
     except Exception as err:
         exception_type = f"{err.__class__.__module__}.{err.__class__.__name__}"
         slack.error(
-            f":x_red: Error in worker `{worker_ip}` while reindexing `{db["target_index"]}`"
+            f":x_red: Error in worker while reindexing `{target_index}`"
             f"(`{exception_type}`): \n"
             f"```\n{err}\n```"
         )

--- a/ingestion_server/ingestion_server/indexer_worker.py
+++ b/ingestion_server/ingestion_server/indexer_worker.py
@@ -52,8 +52,6 @@ def _execute_indexing_task(target_index, start_id, end_id, notify_url):
     if table_name not in MEDIA_TYPES:
         table_name = "image"
     elasticsearch = elasticsearch_connect()
-    progress = Value("d", 0.0)
-    finish_time = Value("d", 0.0)
 
     deleted, mature = get_existence_queries(table_name)
     query = SQL(
@@ -68,7 +66,7 @@ def _execute_indexing_task(target_index, start_id, end_id, notify_url):
         end_id=Literal(end_id),
     )
     log.info(f"Querying {query}")
-    indexer = TableIndexer(elasticsearch, table_name, progress, finish_time)
+    indexer = TableIndexer(elasticsearch, table_name)
     p = Process(
         target=_launch_reindex,
         args=(table_name, target_index, query, indexer, notify_url),

--- a/ingestion_server/ingestion_server/state.py
+++ b/ingestion_server/ingestion_server/state.py
@@ -29,8 +29,7 @@ class WorkerStatus(enum.Enum):
 
 
 TaskData = namedtuple(
-    "TaskData",
-    ["target_index", "task_id", "percent_successful", "percent_completed"]
+    "TaskData", ["target_index", "task_id", "percent_successful", "percent_completed"]
 )
 
 
@@ -103,7 +102,7 @@ def worker_finished(worker_ip, error):
             db["target_index"],
             db["task_id"],
             (completed_workers / total_workers) * 100,
-            ((total_workers - running_workers) / total_workers) * 100
+            ((total_workers - running_workers) / total_workers) * 100,
         )
 
 

--- a/ingestion_server/ingestion_server/state.py
+++ b/ingestion_server/ingestion_server/state.py
@@ -83,17 +83,17 @@ def worker_finished(worker_ip, error):
                 "we are not tracking it."
             )
         total_workers = len(db["worker_statuses"])
-        finished_workers = 0
+        completed_workers = 0
         for worker_key in db["worker_statuses"]:
             status = db["worker_statuses"][worker_key]
             if status == WorkerStatus.RUNNING:
                 log.info(f"{worker_key} is still indexing")
             elif status == WorkerStatus.FINISHED:
-                finished_workers += 1
+                completed_workers += 1
         return {
             "target_index": db["target_index"],
             "task_id": db["task_id"],
-            "percent_completed": (finished_workers / total_workers) * 100,
+            "percent_completed": (completed_workers / total_workers) * 100,
         }
 
 

--- a/ingestion_server/ingestion_server/state.py
+++ b/ingestion_server/ingestion_server/state.py
@@ -12,7 +12,7 @@ import datetime
 import enum
 import logging as log
 import shelve
-from collections import namedtuple
+from typing import NamedTuple
 
 from decouple import config
 from filelock import FileLock
@@ -28,9 +28,11 @@ class WorkerStatus(enum.Enum):
     ERROR = 2
 
 
-TaskData = namedtuple(
-    "TaskData", ["target_index", "task_id", "percent_successful", "percent_completed"]
-)
+class TaskData(NamedTuple):
+    target_index: int
+    task_id: str
+    percent_successful: float
+    percent_completed: float
 
 
 def register_indexing_job(worker_ips, target_index, task_id):
@@ -99,10 +101,10 @@ def worker_finished(worker_ip, error):
             elif status == WorkerStatus.FINISHED:
                 completed_workers += 1
         return TaskData(
-            db["target_index"],
-            db["task_id"],
-            (completed_workers / total_workers) * 100,
-            ((total_workers - running_workers) / total_workers) * 100,
+            target_index=db["target_index"],
+            task_id=db["task_id"],
+            percent_successful=(completed_workers / total_workers) * 100,
+            percent_completed=((total_workers - running_workers) / total_workers) * 100,
         )
 
 

--- a/ingestion_server/ingestion_server/tasks.py
+++ b/ingestion_server/ingestion_server/tasks.py
@@ -68,7 +68,7 @@ class TaskTracker:
                     "error": percent_completed < 100 and not active,
                     "start_time": start_time,
                     "finish_time": finish_time,
-                    "active_workers": bool(active_workers)
+                    "active_workers": bool(active_workers),
                 }
             )
         sorted_results = sorted(results, key=lambda x: x["finish_time"])
@@ -90,7 +90,15 @@ class TaskTracker:
 
 class Task(Process):
     def __init__(
-        self, model, task_type, since_date, progress, task_id, finish_time, active_workers, callback_url
+        self,
+        model,
+        task_type,
+        since_date,
+        progress,
+        task_id,
+        finish_time,
+        active_workers,
+        callback_url,
     ):
         Process.__init__(self)
         self.model = model
@@ -107,7 +115,12 @@ class Task(Process):
             # Map task types to actions.
             elasticsearch = elasticsearch_connect()
             indexer = TableIndexer(
-                elasticsearch, self.model, self.task_id, self.progress, self.finish_time, self.active_workers
+                elasticsearch,
+                self.model,
+                self.task_id,
+                self.progress,
+                self.finish_time,
+                self.active_workers,
             )
             if self.task_type == TaskTypes.REINDEX:
                 slack.verbose(f"`{self.model}`: Beginning Elasticsearch reindex")

--- a/ingestion_server/ingestion_server/tasks.py
+++ b/ingestion_server/ingestion_server/tasks.py
@@ -35,14 +35,16 @@ class TaskTracker:
         self.id_progress = {}
         self.id_start_time = {}
         self.id_finish_time = {}
+        self.id_active_workers = {}
 
-    def add_task(self, task, task_id, action, progress, finish_time):
+    def add_task(self, task, task_id, action, progress, finish_time, active_workers):
         self._prune_old_tasks()
         self.id_task[task_id] = task
         self.id_action[task_id] = action
         self.id_progress[task_id] = progress
         self.id_start_time[task_id] = dt.datetime.utcnow().timestamp()
         self.id_finish_time[task_id] = finish_time
+        self.id_active_workers[task_id] = active_workers
         return task_id
 
     def _prune_old_tasks(self):
@@ -56,6 +58,7 @@ class TaskTracker:
             active = task.is_alive()
             start_time = self.id_start_time[_id]
             finish_time = self.id_finish_time[_id].value
+            active_workers = self.id_active_workers[_id].value
             results.append(
                 {
                     "task_id": _id,
@@ -65,6 +68,7 @@ class TaskTracker:
                     "error": percent_completed < 100 and not active,
                     "start_time": start_time,
                     "finish_time": finish_time,
+                    "active_workers": bool(active_workers)
                 }
             )
         sorted_results = sorted(results, key=lambda x: x["finish_time"])
@@ -86,7 +90,7 @@ class TaskTracker:
 
 class Task(Process):
     def __init__(
-        self, model, task_type, since_date, progress, task_id, finish_time, callback_url
+        self, model, task_type, since_date, progress, task_id, finish_time, active_workers, callback_url
     ):
         Process.__init__(self)
         self.model = model
@@ -95,6 +99,7 @@ class Task(Process):
         self.progress = progress
         self.task_id = task_id
         self.finish_time = finish_time
+        self.active_workers = active_workers
         self.callback_url = callback_url
 
     def run(self):
@@ -102,7 +107,7 @@ class Task(Process):
             # Map task types to actions.
             elasticsearch = elasticsearch_connect()
             indexer = TableIndexer(
-                elasticsearch, self.model, self.progress, self.finish_time
+                elasticsearch, self.model, self.task_id, self.progress, self.finish_time, self.active_workers
             )
             if self.task_type == TaskTypes.REINDEX:
                 slack.verbose(f"`{self.model}`: Beginning Elasticsearch reindex")


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #592 by @stacimc

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR updates the ingestion server to track the status of distributed reindexer workers, and more accurately report the 'active' status of the data refresh task.

Locally, the data refresh task is entirely synchronous. In staging and production, the elasticsearch reindexing step is distributed across worker tasks. The data refresh task schedules this work, then immediately exits. When you poll the ingestion server to check on the status of the task, it reports that it is inactive because the task has completed, even though distributed work is ongoing.

This PR basically:
* adds an `active_workers` property to the already tracked `TaskStatus`, which is by default 'False' when a task is created.
* if we're in staging or production, we'll set this to `True` before schedule distributed reindexing workers, and update it to `False` when the final `go_live` step completes, **OR** if one of the workers fails during reindexing
* updates the `TaskStatus` endpoint to:
    *  take active workers into consideration when reporting the status of the task: `active = task.is_alive() or active_workers`
    * report `percent_completed` as the number of workers that have finished successfully, when running in a distributed environment (staging or prod)
* updates the indexer workers to report errors they encounter to Slack
* only attempts to go live with the new indices if no workers encountered errors

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
This has to be tested in staging.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
