### PR TITLE
Make Exempi library optional for local setup

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -57,7 +57,7 @@ COPY --from=awf /deps /
 COPY --from=awf /usr/local/bin/audiowaveform /usr/local/bin
 
 # - Install system packages needed for running Python dependencies
-#   - libexempi8
+#   - libexempi8: required for watermarking
 #   - libpq-dev: required by `psycopg2`
 # - Create directory for dumping API logs
 RUN apt-get update \

--- a/api/catalog/api/views/image_views.py
+++ b/api/catalog/api/views/image_views.py
@@ -1,7 +1,6 @@
 import io
 import logging
 
-import libxmp
 import piexif
 import requests
 from catalog.api.docs.image_docs import (
@@ -21,7 +20,6 @@ from catalog.api.serializers.image_serializers import (
     OembedSerializer,
     WatermarkRequestSerializer,
 )
-from catalog.api.utils import ccrel
 from catalog.api.utils.exceptions import get_api_exception
 from catalog.api.utils.throttle import OneThousandPerMinute
 from catalog.api.utils.watermark import watermark
@@ -142,6 +140,11 @@ class ImageViewSet(MediaViewSet):
                 "work_landing_page": image.foreign_landing_url,
                 "identifier": str(image.identifier),
             }
+
+            # Import inside a function to allow server run without Exempi library
+            import libxmp
+            from catalog.api.utils import ccrel
+
             try:
                 with_xmp = ccrel.embed_xmp_bytes(img_bytes, work_properties)
                 return FileResponse(with_xmp, content_type="image/jpeg")


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR moves the imports for XMP modules from the top-level into a function. This prevents the watermark-specific libraries from being imported unless they actually need to be used (_read "never"_) and allows running the server on the host directly, without neededing to install any Exempi libraries on the host.

This makes it easy to run a dev setup outside the container which makes it fast and easy to restart, attach debuggers etc.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
0. Orchestrate all servers using `just up`. Stop the web service using `docker-compose stop web`.
1. Rename `env.template` to `.env` so that Pipenv can read it automatically.
2. Run the Django dev server on the host, using `pipenv run python manage.py runserver`.
3. You should be able to run it directly without needing `exempi` or `libexempi` or anything of that sort.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
