### PR TITLE
Add manually triggered action for pushing docker image by SHA

### DIFF
--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -21,18 +21,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download image `${{ github.events.inputs.image }}`
+      - name: Download image `${{ github.event.inputs.image }}`
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: ci_cd.yml
           workflow_conclusion: success
           pr: ${{github.event.pull_request.number}}
-          name: ${{ github.events.inputs.image }}
+          name: ${{ github.event.inputs.image }}
           path: /tmp
 
-      - name: Load and tag image `${{ github.events.inputs.image }}`
+      - name: Load and tag image `${{ github.event.inputs.image }}`
         env:
-          INPUT_IMAGE: ${{ github.events.inputs.image }}
+          INPUT_IMAGE: ${{ github.event.inputs.image }}
         run: |
           docker load --input /tmp/$INPUT_IMAGE.tar
           docker tag openverse-$INPUT_IMAGE \

--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -31,8 +31,8 @@ jobs:
           path: /tmp
 
       - name: Load and tag image `${{ github.events.inputs.image }}`
-        with:
-          image: ${{ github.events.inputs.image }}
+        env:
+          INPUT_IMAGE: ${{ github.events.inputs.image }}
         run: |
           docker load --input /tmp/$INPUT_IMAGE.tar
           docker tag openverse-$INPUT_IMAGE \

--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -1,5 +1,6 @@
 name: Publish Docker images on-demand
 on:
+  pull_request: # DELETEME - only for testing
   workflow_dispatch:
     inputs:
       image:

--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -1,0 +1,38 @@
+name: Publish Docker images on-demand
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: Image to push (either `api` or `ingestion_server`)
+        required: true
+
+jobs:
+  push:
+    name: Publish requested Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download image `${{ env.INPUT_IMAGE }}`
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ci_cd.yml
+          workflow_conclusion: success
+          pr: ${{github.event.pull_request.number}}
+          name: ${{ env.INPUT_IMAGE }}
+          path: /tmp
+
+      - name: Load and tag image `${{ env.INPUT_IMAGE }}`
+        run: |
+          docker load --input /tmp/${{ env.INPUT_IMAGE }}.tar
+          docker tag openverse-${{ env.INPUT_IMAGE }} \
+            ghcr.io/wordpress/openverse-${{ env.INPUT_IMAGE }}:${{ github.sha }}
+          docker push --all-tags ghcr.io/wordpress/openverse-${{ env.INPUT_IMAGE }}

--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -1,6 +1,5 @@
 name: Publish Docker images on-demand
 on:
-  pull_request: # DELETEME - only for testing
   workflow_dispatch:
     inputs:
       image:
@@ -22,18 +21,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download image `${{ env.INPUT_IMAGE }}`
+      - name: Download image `${{ github.events.inputs.image }}`
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: ci_cd.yml
           workflow_conclusion: success
           pr: ${{github.event.pull_request.number}}
-          name: ${{ env.INPUT_IMAGE }}
+          name: ${{ github.events.inputs.image }}
           path: /tmp
 
-      - name: Load and tag image `${{ env.INPUT_IMAGE }}`
+      - name: Load and tag image `${{ github.events.inputs.image }}`
+        with:
+          image: ${{ github.events.inputs.image }}
         run: |
-          docker load --input /tmp/${{ env.INPUT_IMAGE }}.tar
-          docker tag openverse-${{ env.INPUT_IMAGE }} \
-            ghcr.io/wordpress/openverse-${{ env.INPUT_IMAGE }}:${{ github.sha }}
-          docker push --all-tags ghcr.io/wordpress/openverse-${{ env.INPUT_IMAGE }}
+          docker load --input /tmp/$INPUT_IMAGE.tar
+          docker tag openverse-$INPUT_IMAGE \
+            ghcr.io/wordpress/openverse-$INPUT_IMAGE:${{ github.sha }}
+          docker push --all-tags ghcr.io/wordpress/openverse-$INPUT_IMAGE

--- a/api/docs/guides/index.md
+++ b/api/docs/guides/index.md
@@ -11,5 +11,6 @@ quickstart
 run
 test
 document
+publish
 deploy
 ```

--- a/api/docs/guides/publish.md
+++ b/api/docs/guides/publish.md
@@ -1,0 +1,45 @@
+# Publish
+
+The production API and ingestion server Docker images are published to [Github Container Registry](ghcr.io).
+They can be found here:
+* API: [ghcr.io/wordpress/openverse-api](https://ghcr.io/wordpress/openverse-api)
+* Ingestion server: [ghcr.io/wordpress/openverse-ingestion_server](https://ghcr.io/wordpress/openverse-ingestion_server)
+
+These images are published under two conditions: on release, or manually.
+
+## On release
+
+When a new release is cut, the [CI/CD action will run](https://github.com/WordPress/openverse-api/actions/workflows/ci_cd.yml?query=event%3Arelease).
+The final step of this action uploads the Docker images to their respective registries with the following tags:
+* Release reference name, typically the git tag (e.g. `v2.4.2`)
+* `latest`
+* The commit SHA of the tagged commit (e.g. `b25879b84ec9d7b650be689c03384937a93eb06d`)
+
+In some cases, releases may not alter the Docker image.
+For instance, in a release where only the API was changed, the ingestion server image would have the same Docker image hash.
+In these instances, the new tags are added to the existing image.
+
+## Manually
+
+The Docker image for a particular service can also be published manually.
+This process is initiated by the [Publish Docker images on-demand](https://github.com/WordPress/openverse-api/actions/workflows/push_docker_image.yml) action.
+The workflow file for this action can be found here: [`push_docker_image.yml`](https://github.com/WordPress/openverse-api/blob/main/.github/workflows/push_docker_image.yml).
+
+This action **will only publish & tag a service's image with the commit SHA** (i.e. it will not tag with `latest` or the git reference name).
+This is useful for cases where one or more Docker images need to be tested on a staging environment before being merged and cut with a release.
+Note that this action can only run on branches/commits/tags that were made within the last 90 days [due to GitHub's default artifact retention policy](https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization).
+
+### Steps
+
+_Note: [GitHub's documentation provides screenshots for the various steps](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch)_
+
+% TODO: Add screenshots to the below steps once the button is available in the GitHub UI
+
+1. Navigate to the `openverse-api` "Actions" tab in GitHub: [github.com/WordPress/openverse-api/actions](https://github.com/WordPress/openverse-api/actions).
+2. Select the "Publish Docker images on-demand" workflow.
+3. Click the "Run workflow" button.
+4. Select the target branch to build (this can also be `main`).
+5. For the `image` parameter, specify either `api` or `ingestion_server`.
+6. Click the green "Run workflow" button.
+
+The newest run should appear in the Action list, and its status can be tracked from there.

--- a/api/docs/guides/test.md
+++ b/api/docs/guides/test.md
@@ -8,7 +8,7 @@
    ```
    This step is a part of the {doc}`"Quickstart" <./quickstart>` process.
 
-3. Run the tests in an interactive TTY connected to a `web` container.
+2. Run the tests in an interactive TTY connected to a `web` container.
    ```bash
    just api-test
    ```


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #597 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds the ability to tag a Docker image artifact by SHA only and push it to our container registry. The workflow is manually triggered and requires an input on which image to push (only one option is allowed because we are almost never making changes to _both_ the API and ingestion server images). 

The example use case for this: We've made a change to one of the services, and want to deploy it on staging. Our deployment process requires (or will soon require) a tagged Docker image to deploy. Running this workflow will tag and push an image by SHA only, so `latest` is unaffected. We can then deploy by pointing to said commit.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
I'm going to test this in this PR!

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
