### PR TITLE
Override `to_representation` instead of setting default

### DIFF
--- a/api/catalog/api/serializers/media_serializers.py
+++ b/api/catalog/api/serializers/media_serializers.py
@@ -361,7 +361,7 @@ class MediaSerializer(serializers.Serializer):
     )
 
     tags = TagSerializer(
-        default=[],
+        allow_null=True,
         many=True,
         help_text="Tags with detailed metadata, such as accuracy.",
     )
@@ -402,6 +402,12 @@ class MediaSerializer(serializers.Serializer):
 
     def validate_foreign_landing_url(self, value):
         return _add_protocol(value)
+
+    def to_representation(self, *args, **kwargs):
+        repr = super().to_representation(*args, **kwargs)
+        if repr["tags"] is None:
+            repr["tags"] = []  # ``tags`` should always be a list, even if empty
+        return repr
 
 
 class MediaSearchSerializer(serializers.Serializer):


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR fixes an error raised by the `TagSerializer` when supplied with an empty list `[]` as the instance to serialize. This default was earlier added to ensure that the value of the `tag` key is always a list but that goal can be achieved in a better way by overriding `to_representation`.

Error first [reported](https://wordpress.slack.com/archives/C02012JB00N/p1651526277141779) in Slack by @AetherUnbound 

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
0. Check out the PR and run the API services.
1. Make some API calls to `/v1/images`.
2. This error should not appear in the logs. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
