### PR TITLE
Defer ThrottledApplication reference

### DIFF
--- a/api/catalog/api/utils/oauth2_helper.py
+++ b/api/catalog/api/utils/oauth2_helper.py
@@ -3,7 +3,7 @@ import logging
 
 from oauth2_provider.models import AccessToken
 
-from catalog.api.models import ThrottledApplication
+from catalog.api import models
 
 
 log = logging.getLogger(__name__)
@@ -25,11 +25,11 @@ def get_token_info(token: str):
         return None, None, None
     if token.expires >= dt.datetime.now(token.expires.tzinfo):
         try:
-            application = ThrottledApplication.objects.get(accesstoken=token)
+            application = models.ThrottledApplication.objects.get(accesstoken=token)
             client_id = str(application.client_id)
             rate_limit_model = application.rate_limit_model
             verified = application.verified
-        except ThrottledApplication.DoesNotExist:
+        except models.ThrottledApplication.DoesNotExist:
             log.warning("Failed to find application associated with access token.")
             client_id = None
             rate_limit_model = None


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR fixes a circular import that was inadvertently added in #633. The circular import occurred only when `DISABLE_GLOBAL_THROTTLING` was set to `False`. Deferring the reference to `ThrottledApplication` appears to have resolved the import issue.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. Add `DISABLE_GLOBAL_THROTTLING=FALSE` to `api/env.docker`
1. `just up`
1. Observe that the following error **does not** occur:

<details> <summary>Circular Import Error</summary>

```
web_1         | [2022-05-05 18:22:46 +0000] [14] [ERROR] Exception in worker process
web_1         | Traceback (most recent call last):
web_1         |   File "/venv/lib/python3.10/site-packages/rest_framework/settings.py", line 177, in import_from_string
web_1         |     return import_string(val)
web_1         |   File "/venv/lib/python3.10/site-packages/django/utils/module_loading.py", line 30, in import_string
web_1         |     return cached_import(module_path, class_name)
web_1         |   File "/venv/lib/python3.10/site-packages/django/utils/module_loading.py", line 15, in cached_import
web_1         |     import_module(module_path)
web_1         |   File "/usr/local/lib/python3.10/importlib/__init__.py", line 126, in import_module
web_1         |     return _bootstrap._gcd_import(name[level:], package, level)
web_1         |   File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
web_1         |   File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
web_1         |   File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
web_1         |   File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
web_1         |   File "<frozen importlib._bootstrap_external>", line 883, in exec_module
web_1         |   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
web_1         |   File "/api/catalog/api/utils/throttle.py", line 8, in <module>
web_1         |     from catalog.api.utils.oauth2_helper import get_token_info
web_1         |   File "/api/catalog/api/utils/oauth2_helper.py", line 6, in <module>
web_1         |     from catalog.api.models import ThrottledApplication
web_1         | ImportError: cannot import name 'ThrottledApplication' from partially initialized module 'catalog.api.models' (most likely due to a circular import) (/api/catalog/api/models/__init__.py)
web_1         | 
web_1         | During handling of the above exception, another exception occurred:
web_1         | 
web_1         | Traceback (most recent call last):
web_1         |   File "/venv/lib/python3.10/site-packages/gunicorn/arbiter.py", line 589, in spawn_worker
web_1         |     worker.init_process()
web_1         |   File "/venv/lib/python3.10/site-packages/gunicorn/workers/base.py", line 134, in init_process
web_1         |     self.load_wsgi()
web_1         |   File "/venv/lib/python3.10/site-packages/gunicorn/workers/base.py", line 146, in load_wsgi
web_1         |     self.wsgi = self.app.wsgi()
web_1         |   File "/venv/lib/python3.10/site-packages/gunicorn/app/base.py", line 67, in wsgi
web_1         |     self.callable = self.load()
web_1         |   File "/venv/lib/python3.10/site-packages/gunicorn/app/wsgiapp.py", line 58, in load
web_1         |     return self.load_wsgiapp()
web_1         |   File "/venv/lib/python3.10/site-packages/gunicorn/app/wsgiapp.py", line 48, in load_wsgiapp
web_1         |     return util.import_app(self.app_uri)
web_1         |   File "/venv/lib/python3.10/site-packages/gunicorn/util.py", line 359, in import_app
web_1         |     mod = importlib.import_module(module)
web_1         |   File "/usr/local/lib/python3.10/importlib/__init__.py", line 126, in import_module
web_1         |     return _bootstrap._gcd_import(name[level:], package, level)
web_1         |   File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
web_1         |   File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
web_1         |   File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
web_1         |   File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
web_1         |   File "<frozen importlib._bootstrap_external>", line 883, in exec_module
web_1         |   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
web_1         |   File "/api/catalog/wsgi.py", line 22, in <module>
web_1         |     application = get_wsgi_application()
web_1         |   File "/venv/lib/python3.10/site-packages/django/core/wsgi.py", line 12, in get_wsgi_application
web_1         |     django.setup(set_prefix=False)
web_1         |   File "/venv/lib/python3.10/site-packages/django/__init__.py", line 24, in setup
web_1         |     apps.populate(settings.INSTALLED_APPS)
web_1         |   File "/venv/lib/python3.10/site-packages/django/apps/registry.py", line 116, in populate
web_1         |     app_config.import_models()
web_1         |   File "/venv/lib/python3.10/site-packages/django/apps/config.py", line 304, in import_models
web_1         |     self.models_module = import_module(models_module_name)
web_1         |   File "/usr/local/lib/python3.10/importlib/__init__.py", line 126, in import_module
web_1         |     return _bootstrap._gcd_import(name[level:], package, level)
web_1         |   File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
web_1         |   File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
web_1         |   File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
web_1         |   File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
web_1         |   File "<frozen importlib._bootstrap_external>", line 883, in exec_module
web_1         |   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
web_1         |   File "/api/catalog/api/models/__init__.py", line 2, in <module>
web_1         |     from catalog.api.models.audio import (
web_1         |   File "/api/catalog/api/models/audio.py", line 6, in <module>
web_1         |     import catalog.api.controllers.search_controller as search_controller
web_1         |   File "/api/catalog/api/controllers/search_controller.py", line 22, in <module>
web_1         |     from catalog.api.serializers.media_serializers import MediaSearchRequestSerializer
web_1         |   File "/api/catalog/api/serializers/media_serializers.py", line 6, in <module>
web_1         |     from drf_yasg.utils import swagger_serializer_method
web_1         |   File "/venv/lib/python3.10/site-packages/drf_yasg/utils.py", line 16, in <module>
web_1         |     from rest_framework.views import APIView
web_1         |   File "/venv/lib/python3.10/site-packages/rest_framework/views.py", line 104, in <module>
web_1         |     class APIView(View):
web_1         |   File "/venv/lib/python3.10/site-packages/rest_framework/views.py", line 110, in APIView
web_1         |     throttle_classes = api_settings.DEFAULT_THROTTLE_CLASSES
web_1         |   File "/venv/lib/python3.10/site-packages/rest_framework/settings.py", line 225, in __getattr__
web_1         |     val = perform_import(val, attr)
web_1         |   File "/venv/lib/python3.10/site-packages/rest_framework/settings.py", line 168, in perform_import
web_1         |     return [import_from_string(item, setting_name) for item in val]
web_1         |   File "/venv/lib/python3.10/site-packages/rest_framework/settings.py", line 168, in <listcomp>
web_1         |     return [import_from_string(item, setting_name) for item in val]
web_1         |   File "/venv/lib/python3.10/site-packages/rest_framework/settings.py", line 180, in import_from_string
web_1         |     raise ImportError(msg)
web_1         | ImportError: Could not import 'catalog.api.utils.throttle.BurstRateThrottle' for API setting 'DEFAULT_THROTTLE_CLASSES'. ImportError: cannot import name 'ThrottledApplication' from partially initialized module 'catalog.api.models' (most likely due to a circular import) (/api/catalog/api/models/__init__.py).
web_1         | [2022-05-05 18:22:46 +0000] [14] [INFO] Worker exiting (pid: 14)
web_1         | [2022-05-05 18:22:46 +0000] [15] [ERROR] Exception in worker process
web_1         | Traceback (most recent call last):
web_1         |   File "/venv/lib/python3.10/site-packages/rest_framework/settings.py", line 177, in import_from_string
web_1         |     return import_string(val)
web_1         |   File "/venv/lib/python3.10/site-packages/django/utils/module_loading.py", line 30, in import_string
web_1         |     return cached_import(module_path, class_name)
web_1         |   File "/venv/lib/python3.10/site-packages/django/utils/module_loading.py", line 15, in cached_import
web_1         |     import_module(module_path)
web_1         |   File "/usr/local/lib/python3.10/importlib/__init__.py", line 126, in import_module
web_1         |     return _bootstrap._gcd_import(name[level:], package, level)
web_1         |   File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
web_1         |   File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
web_1         |   File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
web_1         |   File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
web_1         |   File "<frozen importlib._bootstrap_external>", line 883, in exec_module
web_1         |   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
web_1         |   File "/api/catalog/api/utils/throttle.py", line 8, in <module>
web_1         |     from catalog.api.utils.oauth2_helper import get_token_info
web_1         |   File "/api/catalog/api/utils/oauth2_helper.py", line 6, in <module>
web_1         |     from catalog.api.models import ThrottledApplication
web_1         | ImportError: cannot import name 'ThrottledApplication' from partially initialized module 'catalog.api.models' (most likely due to a circular import) (/api/catalog/api/models/__init__.py)
web_1         | 
web_1         | During handling of the above exception, another exception occurred:
web_1         | 
web_1         | Traceback (most recent call last):
web_1         |   File "/venv/lib/python3.10/site-packages/gunicorn/arbiter.py", line 589, in spawn_worker
web_1         |     worker.init_process()
web_1         |   File "/venv/lib/python3.10/site-packages/gunicorn/workers/base.py", line 134, in init_process
web_1         |     self.load_wsgi()
web_1         |   File "/venv/lib/python3.10/site-packages/gunicorn/workers/base.py", line 146, in load_wsgi
web_1         |     self.wsgi = self.app.wsgi()
web_1         |   File "/venv/lib/python3.10/site-packages/gunicorn/app/base.py", line 67, in wsgi
web_1         |     self.callable = self.load()
web_1         |   File "/venv/lib/python3.10/site-packages/gunicorn/app/wsgiapp.py", line 58, in load
web_1         |     return self.load_wsgiapp()
web_1         |   File "/venv/lib/python3.10/site-packages/gunicorn/app/wsgiapp.py", line 48, in load_wsgiapp
web_1         |     return util.import_app(self.app_uri)
web_1         |   File "/venv/lib/python3.10/site-packages/gunicorn/util.py", line 359, in import_app
web_1         |     mod = importlib.import_module(module)
web_1         |   File "/usr/local/lib/python3.10/importlib/__init__.py", line 126, in import_module
web_1         |     return _bootstrap._gcd_import(name[level:], package, level)
web_1         |   File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
web_1         |   File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
web_1         |   File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
web_1         |   File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
web_1         |   File "<frozen importlib._bootstrap_external>", line 883, in exec_module
web_1         |   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
web_1         |   File "/api/catalog/wsgi.py", line 22, in <module>
web_1         |     application = get_wsgi_application()
web_1         |   File "/venv/lib/python3.10/site-packages/django/core/wsgi.py", line 12, in get_wsgi_application
web_1         |     django.setup(set_prefix=False)
web_1         |   File "/venv/lib/python3.10/site-packages/django/__init__.py", line 24, in setup
web_1         |     apps.populate(settings.INSTALLED_APPS)
web_1         |   File "/venv/lib/python3.10/site-packages/django/apps/registry.py", line 116, in populate
web_1         |     app_config.import_models()
web_1         |   File "/venv/lib/python3.10/site-packages/django/apps/config.py", line 304, in import_models
web_1         |     self.models_module = import_module(models_module_name)
web_1         |   File "/usr/local/lib/python3.10/importlib/__init__.py", line 126, in import_module
web_1         |     return _bootstrap._gcd_import(name[level:], package, level)
web_1         |   File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
web_1         |   File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
web_1         |   File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
web_1         |   File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
web_1         |   File "<frozen importlib._bootstrap_external>", line 883, in exec_module
web_1         |   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
web_1         |   File "/api/catalog/api/models/__init__.py", line 2, in <module>
web_1         |     from catalog.api.models.audio import (
web_1         |   File "/api/catalog/api/models/audio.py", line 6, in <module>
web_1         |     import catalog.api.controllers.search_controller as search_controller
web_1         |   File "/api/catalog/api/controllers/search_controller.py", line 22, in <module>
web_1         |     from catalog.api.serializers.media_serializers import MediaSearchRequestSerializer
web_1         |   File "/api/catalog/api/serializers/media_serializers.py", line 6, in <module>
web_1         |     from drf_yasg.utils import swagger_serializer_method
web_1         |   File "/venv/lib/python3.10/site-packages/drf_yasg/utils.py", line 16, in <module>
web_1         |     from rest_framework.views import APIView
web_1         |   File "/venv/lib/python3.10/site-packages/rest_framework/views.py", line 104, in <module>
web_1         |     class APIView(View):
web_1         |   File "/venv/lib/python3.10/site-packages/rest_framework/views.py", line 110, in APIView
web_1         |     throttle_classes = api_settings.DEFAULT_THROTTLE_CLASSES
web_1         |   File "/venv/lib/python3.10/site-packages/rest_framework/settings.py", line 225, in __getattr__
web_1         |     val = perform_import(val, attr)
web_1         |   File "/venv/lib/python3.10/site-packages/rest_framework/settings.py", line 168, in perform_import
web_1         |     return [import_from_string(item, setting_name) for item in val]
web_1         |   File "/venv/lib/python3.10/site-packages/rest_framework/settings.py", line 168, in <listcomp>
web_1         |     return [import_from_string(item, setting_name) for item in val]
web_1         |   File "/venv/lib/python3.10/site-packages/rest_framework/settings.py", line 180, in import_from_string
web_1         |     raise ImportError(msg)
web_1         | ImportError: Could not import 'catalog.api.utils.throttle.BurstRateThrottle' for API setting 'DEFAULT_THROTTLE_CLASSES'. ImportError: cannot import name 'ThrottledApplication' from partially initialized module 'catalog.api.models' (most likely due to a circular import) (/api/catalog/api/models/__init__.py).
```

</details>

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
