### PR TITLE
 Add command to resend verification emails

### DIFF
--- a/api/catalog/management/commands/resendoauthverification.py
+++ b/api/catalog/management/commands/resendoauthverification.py
@@ -1,0 +1,145 @@
+from dataclasses import dataclass
+
+from django.core.mail import send_mail
+from django.db import transaction
+
+from django_tqdm import BaseCommand
+from django_redis import get_redis_connection
+
+from catalog.api.models.oauth import OAuth2Verification, OAuth2Registration, ThrottledApplication
+
+verification_msg_template = """
+The Openverse API OAuth2 email verification process has recently been fixed.
+We have detected that you attempted to register an application using this email.
+
+To verify your Openverse API credentials, click on the following link:
+
+{link}
+
+If you believe you received this message in error, please disregard it.
+"""
+
+@dataclass
+class Result:
+    saved_application_name: str
+    deleted_applications: int = 0
+
+class Command(BaseCommand):
+    help = "Resends verification emails for unverified Oauth applications."
+    """
+    This command is meant to be used a single time in production to remediate
+    failed email sending. It puts a lock in Redis to prevent it from being run
+    multiple times.
+
+    If for some reason it needs to be run a second time, pass the --force flag
+    to release the lock.
+    """
+    lock_name = 'resendoauthverification:lock'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--force", help="Force running the command even if a lock already exists in redis", type=bool
+        )
+
+    @transaction.atomic
+    def _handle_email(self, email):
+        """
+        1. Get all application IDs for the email
+        2. Use the one with the lowest ID as the "original" attempt
+        3. Delete the rest
+        4. Delete OAuth2Registrations for the email not associated with the "original" application
+        5. Delete OAuth2Verifications for the email not associated with the "original" application
+
+        This ignores the fact that someone could have tried to register multiple unverified but distinct
+        applications under the same email. This is unlikely given that none of the requests would have
+        worked and that the "feature" isn't explicitly documented anyway.
+        """
+        application_ids = list(OAuth2Registration.objects.filter(
+            email=email
+        ).select_related('associated_application').order_by('id').values('pk'))
+
+        application_to_verify = ThrottledApplication.objects.get(application_ids[0])
+
+        deleted_applications = 0
+        if len(application_ids) > 1:
+            applications_to_delete_ids = application_ids[1:]
+            ThrottledApplication.objects.filter(pk__in=applications_to_delete_ids).delete()
+            OAuth2Registration.objects.filter(email=email).exclude(name=application_to_verify.name).delete()
+            OAuth2Verification.objects.filter(email=email).exclude(associated_application=application_to_verify).delete()
+            deleted_applications = len(applications_to_delete_ids)
+        
+        verification = OAuth2Verification.objects.get(associated_application=application_to_verify)
+        token = verification.code
+        link = request.build_absolute_uri(reverse("verify-email", [token]))
+        verification_msg = verification_msg_template.format(
+            link=link
+        )
+        send_mail(
+            subject="Verify your API credentials",
+            message=verification_msg,
+            from_email=settings.EMAIL_SENDER,
+            recipient_list=[verification.email],
+            fail_silently=False,
+        )
+
+        return Result(
+            saved_application_name=application_to_verify.name,
+            deleted_applications=deleted_applications,
+        )
+
+    def handle(self, *args, **options):
+        redis = get_redis_connection('default')
+
+        if redis.exists(self.lock_name) and not options['force']:
+            self.error("A lock already exists for the resend oauth verification command. Exiting.")
+            return
+        
+        redis.set(self.lock_name, True)
+
+        try:
+            emails_with_verified_applications = OAuth2Verification.objects.filter(
+                associated_application__verified=True
+            ).values('email')
+            emails_with_zero_verified_applications = list(OAuth2Verification.objects.exclude(
+                email__in=emails_with_verified_applications
+            ).values('email').distinct())
+
+            count_to_process = len(emails_with_zero_verified_applications)
+            results = []
+            errored_emails = []
+
+            with self.tqdm(total=count_to_process) as progress:
+                for email in emails_with_zero_verified_applications:
+                    try:
+                        results.append(self._handle_email(email))
+                    except BaseException as err:
+                        errored_emails.append(email)
+                        self.error(f"Unable to process {email}: " f"{err}")
+
+                    progress.update(1)
+        finally:
+            redis.delete(self.lock_name)
+
+        if errored_emails:
+            joined = "\n".join(errored_emails)
+            self.info(
+                self.style.WARNING(
+                    f"The following emails were unable to be processed.\n\n"
+                    f"{joined}"
+                    f"\n\nPlease check the output above for the error related to each email."
+                )
+            )
+
+        formatted_results = "\n\n".join(
+            (
+                f"Application name: {result.saved_application_name}\n"
+                f"Cleaned related application count: {result.deleted_applications}\n"
+            ) for result in results
+        )
+
+        self.info(
+            self.style.SUCCESS(
+                f"The following applications had email verifications sent.\n\n"
+                f"{formatted_results}"
+            )
+        )

--- a/api/catalog/management/commands/resendoauthverification.py
+++ b/api/catalog/management/commands/resendoauthverification.py
@@ -1,12 +1,27 @@
 from dataclasses import dataclass
 
 from django.core.mail import send_mail
+from django.conf import settings
 from django.db import transaction
+from django.db.models import Q
+from rest_framework.reverse import reverse
 
-from django_tqdm import BaseCommand
 from django_redis import get_redis_connection
+from django_tqdm import BaseCommand
 
-from catalog.api.models.oauth import OAuth2Verification, OAuth2Registration, ThrottledApplication
+from catalog.api.models.oauth import (
+    OAuth2Registration,
+    OAuth2Verification,
+    ThrottledApplication,
+)
+
+
+def get_input(text):
+    """
+    Wrapped ``input`` to allow patching in unittests
+    """
+    return input(text)
+
 
 verification_msg_template = """
 The Openverse API OAuth2 email verification process has recently been fixed.
@@ -19,106 +34,154 @@ To verify your Openverse API credentials, click on the following link:
 If you believe you received this message in error, please disregard it.
 """
 
+
 @dataclass
 class Result:
     saved_application_name: str
-    deleted_applications: int = 0
+    deleted_applications: int
+    deleted_registrations: int
+    deleted_verifications: int
+
 
 class Command(BaseCommand):
     help = "Resends verification emails for unverified Oauth applications."
     """
     This command is meant to be used a single time in production to remediate
-    failed email sending. It puts a lock in Redis to prevent it from being run
-    multiple times.
+    failed email sending.
 
-    If for some reason it needs to be run a second time, pass the --force flag
-    to release the lock.
+    It stores a cache of successfully sent emails in Redis, so running it multiple
+    times (in case of failure) should not be an issue.
     """
-    lock_name = 'resendoauthverification:lock'
+
+    processed_key = "resendoauthverification:processed"
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "--force", help="Force running the command even if a lock already exists in redis", type=bool
+            "--dry_run",
+            help="Count the records that will be removed but don't apply any changes.",
+            type=bool,
+            default=True,
         )
 
     @transaction.atomic
-    def _handle_email(self, email):
+    def _handle_email(self, email, dry):
         """
         1. Get all application IDs for the email
         2. Use the one with the lowest ID as the "original" attempt
         3. Delete the rest
-        4. Delete OAuth2Registrations for the email not associated with the "original" application
-        5. Delete OAuth2Verifications for the email not associated with the "original" application
+        4. Delete OAuth2Registrations for the email not associated
+            with the "original" application
+        5. Delete OAuth2Verifications for the email not associated
+            with the "original" application
 
-        This ignores the fact that someone could have tried to register multiple unverified but distinct
-        applications under the same email. This is unlikely given that none of the requests would have
-        worked and that the "feature" isn't explicitly documented anyway.
+        This ignores the fact that someone could have tried to register
+        multiple unverified but distinct applications under the same email.
+        This is unlikely given that none of the requests would have worked
+        and that the "feature" isn't explicitly documented anyway.
         """
-        application_ids = list(OAuth2Registration.objects.filter(
-            email=email
-        ).select_related('associated_application').order_by('id').values('pk'))
+        application_ids = list(
+            OAuth2Registration.objects.filter(email=email)
+            .select_related("associated_application")
+            .order_by("id")
+            .values_list("pk", flat=True)
+        )
 
-        application_to_verify = ThrottledApplication.objects.get(application_ids[0])
+        application_to_verify = ThrottledApplication.objects.get(pk=application_ids[0])
 
         deleted_applications = 0
         if len(application_ids) > 1:
             applications_to_delete_ids = application_ids[1:]
-            ThrottledApplication.objects.filter(pk__in=applications_to_delete_ids).delete()
-            OAuth2Registration.objects.filter(email=email).exclude(name=application_to_verify.name).delete()
-            OAuth2Verification.objects.filter(email=email).exclude(associated_application=application_to_verify).delete()
             deleted_applications = len(applications_to_delete_ids)
-        
-        verification = OAuth2Verification.objects.get(associated_application=application_to_verify)
-        token = verification.code
-        link = request.build_absolute_uri(reverse("verify-email", [token]))
-        verification_msg = verification_msg_template.format(
-            link=link
-        )
-        send_mail(
-            subject="Verify your API credentials",
-            message=verification_msg,
-            from_email=settings.EMAIL_SENDER,
-            recipient_list=[verification.email],
-            fail_silently=False,
-        )
+            if not dry:
+                ThrottledApplication.objects.filter(
+                    pk__in=applications_to_delete_ids
+                ).delete()
+
+            registrations_to_delete = OAuth2Registration.objects.filter(
+                email=email
+            ).exclude(name=application_to_verify.name)
+            deleted_registrations = registrations_to_delete.count()
+            if not dry:
+                registrations_to_delete.delete()
+
+            verifications_to_delete = OAuth2Verification.objects.filter(
+                email=email
+            ).exclude(associated_application=application_to_verify)
+            deleted_verifications = verifications_to_delete.count()
+            if not dry:
+                verifications_to_delete.delete()
+
+        if not dry:
+            verification = OAuth2Verification.objects.get(
+                associated_application=application_to_verify
+            )
+            token = verification.code
+            # We don't have access to `request.build_absolute_uri` so we
+            # have to build it ourselves for the production endpoint
+            link = f"https://api.openverse.engineering/{reverse('verify-email', [token])}"
+            verification_msg = verification_msg_template.format(link=link)
+            send_mail(
+                subject="Verify your API credentials",
+                message=verification_msg,
+                from_email=settings.DEFAULT_FROM_EMAIL,
+                recipient_list=[verification.email],
+                fail_silently=False,
+            )
 
         return Result(
             saved_application_name=application_to_verify.name,
             deleted_applications=deleted_applications,
+            deleted_registrations=deleted_registrations,
+            deleted_verifications=deleted_verifications,
         )
 
     def handle(self, *args, **options):
-        redis = get_redis_connection('default')
+        dry = options["dry_run"]
+        if not dry:
+            self.info(
+                self.style.WARNING(
+                    "This is NOT a dry run. Are you sure you wish to proceed? "
+                    "Respond 'yes' in all uppercase to proceed.\n"
+                )
+            )
+            if get_input(": ") != "YES":
+                self.error("Exiting.")
+                exit(1)
 
-        if redis.exists(self.lock_name) and not options['force']:
-            self.error("A lock already exists for the resend oauth verification command. Exiting.")
-            return
-        
-        redis.set(self.lock_name, True)
+        redis = get_redis_connection("default")
 
-        try:
-            emails_with_verified_applications = OAuth2Verification.objects.filter(
-                associated_application__verified=True
-            ).values('email')
-            emails_with_zero_verified_applications = list(OAuth2Verification.objects.exclude(
+        already_processed_emails = [
+            email.decode('utf-8') for email in redis.smembers(self.processed_key)
+        ]
+
+        emails_with_verified_applications = OAuth2Verification.objects.filter(
+            Q(associated_application__verified=True) |
+            Q(email__in=already_processed_emails)
+        ).values_list("email", flat=True)
+
+        emails_with_zero_verified_applications = list(
+            OAuth2Verification.objects.exclude(
                 email__in=emails_with_verified_applications
-            ).values('email').distinct())
+            )
+            .values_list("email", flat=True)
+            .distinct()
+        )
 
-            count_to_process = len(emails_with_zero_verified_applications)
-            results = []
-            errored_emails = []
+        count_to_process = len(emails_with_zero_verified_applications)
+        results = []
+        errored_emails = []
 
-            with self.tqdm(total=count_to_process) as progress:
-                for email in emails_with_zero_verified_applications:
-                    try:
-                        results.append(self._handle_email(email))
-                    except BaseException as err:
-                        errored_emails.append(email)
-                        self.error(f"Unable to process {email}: " f"{err}")
+        with self.tqdm(total=count_to_process) as progress:
+            for email in emails_with_zero_verified_applications:
+                try:
+                    results.append(self._handle_email(email, dry))
+                    if not dry:
+                        redis.sadd(self.processed_key, email)
+                except BaseException as err:
+                    errored_emails.append(email)
+                    self.error(f"Unable to process {email}: " f"{err}")
 
-                    progress.update(1)
-        finally:
-            redis.delete(self.lock_name)
+                progress.update(1)
 
         if errored_emails:
             joined = "\n".join(errored_emails)
@@ -126,7 +189,8 @@ class Command(BaseCommand):
                 self.style.WARNING(
                     f"The following emails were unable to be processed.\n\n"
                     f"{joined}"
-                    f"\n\nPlease check the output above for the error related to each email."
+                    "\n\nPlease check the output above for the error related"
+                    "to each email."
                 )
             )
 
@@ -134,7 +198,10 @@ class Command(BaseCommand):
             (
                 f"Application name: {result.saved_application_name}\n"
                 f"Cleaned related application count: {result.deleted_applications}\n"
-            ) for result in results
+                f"Cleaned related verification count: {result.deleted_verifications}\n"
+                f"Cleaned related registration count: {result.deleted_registrations}\n"
+            )
+            for result in results
         )
 
         self.info(
@@ -143,3 +210,10 @@ class Command(BaseCommand):
                 f"{formatted_results}"
             )
         )
+
+        if dry:
+            self.info(
+                self.style.WARNING(
+                    "The above was a dry run and no records were actually affected."
+                )
+            )

--- a/api/test/factory/models/oauth2.py
+++ b/api/test/factory/models/oauth2.py
@@ -4,13 +4,18 @@ import factory
 from factory.django import DjangoModelFactory
 from oauth2_provider.models import AccessToken
 
-from catalog.api.models.oauth import ThrottledApplication, OAuth2Registration, OAuth2Verification
+from catalog.api.models.oauth import (
+    OAuth2Registration,
+    OAuth2Verification,
+    ThrottledApplication,
+)
 
 
 class ThrottledApplicationFactory(DjangoModelFactory):
     class Meta:
         model = ThrottledApplication
 
+    name = Faker("md5")
     client_type = Faker(
         "random_choice_field", choices=ThrottledApplication.CLIENT_TYPES
     )
@@ -23,7 +28,7 @@ class OAuth2RegistrationFactory(DjangoModelFactory):
     class Meta:
         model = OAuth2Registration
 
-    name = Faker("company")
+    name = Faker("md5")
     description = Faker("catch_phrase")
     email = Faker("email")
 

--- a/api/test/factory/models/oauth2.py
+++ b/api/test/factory/models/oauth2.py
@@ -4,7 +4,7 @@ import factory
 from factory.django import DjangoModelFactory
 from oauth2_provider.models import AccessToken
 
-from catalog.api.models.oauth import ThrottledApplication
+from catalog.api.models.oauth import ThrottledApplication, OAuth2Registration, OAuth2Verification
 
 
 class ThrottledApplicationFactory(DjangoModelFactory):
@@ -17,6 +17,24 @@ class ThrottledApplicationFactory(DjangoModelFactory):
     authorization_grant_type = Faker(
         "random_choice_field", choices=ThrottledApplication.GRANT_TYPES
     )
+
+
+class OAuth2RegistrationFactory(DjangoModelFactory):
+    class Meta:
+        model = OAuth2Registration
+
+    name = Faker("company")
+    description = Faker("catch_phrase")
+    email = Faker("email")
+
+
+class OAuth2VerificationFactory(DjangoModelFactory):
+    class Meta:
+        model = OAuth2Verification
+
+    associated_application = factory.SubFactory(ThrottledApplicationFactory)
+    email = Faker("email")
+    code = Faker("md5")
 
 
 class AccessTokenFactory(DjangoModelFactory):

--- a/api/test/unit/management/commands/resendoauthverification_test.py
+++ b/api/test/unit/management/commands/resendoauthverification_test.py
@@ -1,8 +1,87 @@
 from dataclasses import dataclass
+from io import StringIO
+from unittest import mock
+import smtplib
 
-from catalog.api.models.oauth import OAuth2Registration, OAuth2Verification, ThrottledApplication
+from django.core.management import call_command
 
-from test.factory.models.oauth2 import OAuth2RegistrationFactory, OAuth2VerificationFactory, ThrottledApplicationFactory
+import pytest
+from fakeredis import FakeRedis
+
+from test.factory.models.oauth2 import (
+    OAuth2RegistrationFactory,
+    OAuth2VerificationFactory,
+    ThrottledApplicationFactory,
+)
+
+from catalog.api.models.oauth import (
+    OAuth2Registration,
+    OAuth2Verification,
+    ThrottledApplication,
+)
+
+
+command_module_path = "catalog.management.commands.resendoauthverification"
+
+
+@pytest.fixture(autouse=True)
+def redis(monkeypatch) -> FakeRedis:
+    fake_redis = FakeRedis()
+
+    def get_redis_connection(*args, **kwargs):
+        return fake_redis
+
+    monkeypatch.setattr(
+        f"{command_module_path}.get_redis_connection", get_redis_connection
+    )
+
+    yield fake_redis
+    fake_redis.client().close()
+
+
+@dataclass
+class CapturedEmail:
+    message: str
+    recipient_list: list[str]
+
+
+@pytest.fixture
+def captured_emails(monkeypatch) -> list[CapturedEmail]:
+    captured = []
+    
+    def send_mail(*args, **kwargs):
+        captured.append(
+            CapturedEmail(
+                message=kwargs["message"],
+                recipient_list=kwargs["recipient_list"],
+            )
+        )
+
+    monkeypatch.setattr(
+        f"{command_module_path}.send_mail", send_mail
+    )
+
+    yield captured
+
+
+@pytest.fixture
+def failed_emails(monkeypatch) -> list[CapturedEmail]:
+    failed = []
+
+    def send_mail(*args, **kwargs):
+        failed.append(
+            CapturedEmail(
+                message=kwargs["message"],
+                recipient_list=kwargs["recipient_list"],
+            )
+        )
+        raise smtplib.SMTPAuthenticationError(1, "beep boop bad password")
+
+    monkeypatch.setattr(
+        f"{command_module_path}.send_mail", send_mail
+    )
+
+    yield failed
 
 
 @dataclass
@@ -24,15 +103,175 @@ def cohesive_verification(email=None) -> OAuthGroup:
 
     registration = OAuth2RegistrationFactory.create(**options)
 
-    application = ThrottledApplicationFactory.create()
+    application = ThrottledApplicationFactory.create(name=registration.name)
 
     verification = OAuth2VerificationFactory.create(
-        email=registration.email,
-        associated_application=application
+        email=registration.email, associated_application=application
     )
 
     return OAuthGroup(
-        registration=registration,
-        application=application,
-        verification=verification
+        registration=registration, application=application, verification=verification
     )
+
+
+@dataclass
+class CleanableEmail:
+    email: str
+    keep_group: OAuthGroup
+    clean_groups: list[OAuthGroup]
+
+
+def make_cleanable_email():
+    keep = cohesive_verification()
+    clean = [
+        cohesive_verification(
+            email=keep.registration.email
+        )
+        for _ in range(10)
+    ]
+
+    return CleanableEmail(
+        email=keep.registration.email,
+        keep_group=keep,
+        clean_groups=clean
+    )
+
+
+@pytest.fixture
+def cleanable_email():
+    return make_cleanable_email()
+
+
+def is_group_captured(email: CapturedEmail, group: OAuthGroup) -> bool:
+    return (
+        group.verification.code in email.message and
+        [group.registration.email] == email.recipient_list
+    )
+
+
+def count_captured_emails_for_group(
+    captured_emails: list[CapturedEmail],
+    oauth_group: OAuthGroup
+) -> int:
+    count = 0
+    for email in captured_emails:
+        if is_group_captured(email, oauth_group):
+            count += 1
+    
+    return count
+    
+
+
+def assert_one_email_sent(
+    captured_emails: list[CapturedEmail],
+    oauth_group: OAuthGroup
+):
+    assert count_captured_emails_for_group(captured_emails, oauth_group) == 1
+
+def assert_cleaned_and_sent(cleanable_email: CleanableEmail, captured_emails: list[CapturedEmail]):
+    keep = cleanable_email.keep_group
+    assert OAuth2Registration.objects.filter(pk=keep.registration.pk).exists() == True
+    assert OAuth2Verification.objects.filter(pk=keep.verification.pk).exists() == True
+    assert ThrottledApplication.objects.filter(pk=keep.application.pk).exists() == True
+
+    for cleaned in cleanable_email.clean_groups:
+        assert OAuth2Registration.objects.filter(pk=cleaned.registration.pk).exists() == False
+        assert OAuth2Verification.objects.filter(pk=cleaned.verification.pk).exists() == False
+        assert ThrottledApplication.objects.filter(pk=cleaned.application.pk).exists() == False
+
+    assert_one_email_sent(captured_emails, keep)
+
+
+def call_resendoauthverification(input_response="YES", **options):
+    out = StringIO()
+    err = StringIO()
+    options.update(stdout=out, stderr=err)
+    with mock.patch(f"{command_module_path}.get_input", return_value=input_response):
+        call_command("resendoauthverification", **options)
+
+    res = out.getvalue(), err.getvalue()
+    print(res)
+
+    return res
+
+
+@pytest.mark.parametrize(
+    "return_value",
+    (
+        None,
+        "",
+        "no"
+        "NO",
+        "yes",  # must be exactly YES
+    )
+)
+def test_should_exit_if_wet_unconfirmed(return_value):
+    with pytest.raises(SystemExit):
+        call_resendoauthverification(input_response=return_value, dry_run=False)
+
+
+@pytest.mark.django_db
+def test_should_continue_if_wet_confirmed_with_YES(captured_emails, cleanable_email):
+    call_resendoauthverification(input_response="YES", dry_run=False)
+    assert_cleaned_and_sent(cleanable_email, captured_emails)
+
+
+@pytest.mark.django_db
+def test_should_clean_for_several_emails(captured_emails):
+    cleanables = [
+        make_cleanable_email() for _ in range(10)
+    ]
+    call_resendoauthverification(dry_run=False)
+    for cleanable in cleanables:
+        assert_cleaned_and_sent(cleanable, captured_emails)
+
+
+@pytest.mark.django_db
+def test_should_not_resend_for_already_sent(captured_emails):
+    cleanables = [
+        make_cleanable_email() for _ in range(10)
+    ]
+    call_resendoauthverification(dry_run=False)
+    for cleanable in cleanables:
+        assert_cleaned_and_sent(cleanable, captured_emails)
+    call_resendoauthverification(dry_run=False)
+    for cleanable in cleanables:
+        assert_one_email_sent(captured_emails, cleanable.keep_group)
+
+
+@pytest.mark.django_db
+def test_should_not_count_email_as_sent_if_failed_and_rollback(failed_emails, cleanable_email, redis):
+    call_resendoauthverification(dry_run=False)
+    assert count_captured_emails_for_group(failed_emails, cleanable_email.keep_group) == 1
+
+    keep = cleanable_email.keep_group
+    assert OAuth2Registration.objects.filter(pk=keep.registration.pk).exists() == True
+    assert OAuth2Verification.objects.filter(pk=keep.verification.pk).exists() == True
+    assert ThrottledApplication.objects.filter(pk=keep.application.pk).exists() == True
+
+    # Assert these all still exist
+    for cleaned in cleanable_email.clean_groups:
+        assert OAuth2Registration.objects.filter(pk=cleaned.registration.pk).exists() == True
+        assert OAuth2Verification.objects.filter(pk=cleaned.verification.pk).exists() == True
+        assert ThrottledApplication.objects.filter(pk=cleaned.application.pk).exists() == True
+
+    assert redis.sismember("resendoauthverification:processed", keep.registration.email) == False
+
+
+@pytest.mark.django_db
+def test_should_not_delete_or_send_if_dry_run(cleanable_email, captured_emails, redis):
+    call_resendoauthverification(dry_run=True)
+    assert count_captured_emails_for_group(captured_emails, cleanable_email.keep_group) == 0
+
+    keep = cleanable_email.keep_group
+    assert OAuth2Registration.objects.filter(pk=keep.registration.pk).exists() == True
+    assert OAuth2Verification.objects.filter(pk=keep.verification.pk).exists() == True
+    assert ThrottledApplication.objects.filter(pk=keep.application.pk).exists() == True
+
+    # Assert these all still exist (no clean up has happened)
+    for cleaned in cleanable_email.clean_groups:
+        assert OAuth2Registration.objects.filter(pk=cleaned.registration.pk).exists() == True
+        assert OAuth2Verification.objects.filter(pk=cleaned.verification.pk).exists() == True
+        assert ThrottledApplication.objects.filter(pk=cleaned.application.pk).exists() == True
+
+    assert redis.sismember("resendoauthverification:processed", keep.registration.email) == False

--- a/api/test/unit/management/commands/resendoauthverification_test.py
+++ b/api/test/unit/management/commands/resendoauthverification_test.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+
+from catalog.api.models.oauth import OAuth2Registration, OAuth2Verification, ThrottledApplication
+
+from test.factory.models.oauth2 import OAuth2RegistrationFactory, OAuth2VerificationFactory, ThrottledApplicationFactory
+
+
+@dataclass
+class OAuthGroup:
+    registration: OAuth2Registration
+    application: ThrottledApplication
+    verification: OAuth2Verification
+
+
+def cohesive_verification(email=None) -> OAuthGroup:
+    """
+    Generate a registration, application, and verification.
+
+    Optionally associate it with a specific email.
+    """
+    options = {}
+    if email:
+        options.update(email=email)
+
+    registration = OAuth2RegistrationFactory.create(**options)
+
+    application = ThrottledApplicationFactory.create()
+
+    verification = OAuth2VerificationFactory.create(
+        email=registration.email,
+        associated_application=application
+    )
+
+    return OAuthGroup(
+        registration=registration,
+        application=application,
+        verification=verification
+    )

--- a/api/test/unit/management/commands/resendoauthverification_test.py
+++ b/api/test/unit/management/commands/resendoauthverification_test.py
@@ -19,8 +19,8 @@ from catalog.api.models.oauth import (
     OAuth2Verification,
     ThrottledApplication,
 )
-from catalog.api.views.oauth2_views import Register
 from catalog.api.utils.throttle import ExemptionAwareThrottle
+from catalog.api.views.oauth2_views import Register
 
 
 command_module_path = "catalog.management.commands.resendoauthverification"
@@ -316,11 +316,17 @@ def test_should_not_send_for_verified_emails(cleanable_email, captured_emails):
 
 def register_with_email_times(email: str, times: int) -> list:
     request_factory = APIRequestFactory()
-    requests = [request_factory.post('/', data={
-        "name": f"{email}'s sweet app #{i}",
-        "email": email,
-        "description": f"{email}'s sweet app"
-    }) for i in range(times)]
+    requests = [
+        request_factory.post(
+            "/",
+            data={
+                "name": f"{email}'s sweet app #{i}",
+                "email": email,
+                "description": f"{email}'s sweet app",
+            },
+        )
+        for i in range(times)
+    ]
 
     view = Register.as_view()
     return [view(request) for request in requests]
@@ -334,8 +340,10 @@ def test_create_tokens_with_view(captured_emails):
         "pen_tester@example.org",
     ]
 
-    with mock.patch('catalog.api.views.oauth2_views.send_mail'):
-        with mock.patch.object(ExemptionAwareThrottle, 'allow_request', return_value=True):
+    with mock.patch("catalog.api.views.oauth2_views.send_mail"):
+        with mock.patch.object(
+            ExemptionAwareThrottle, "allow_request", return_value=True
+        ):
             for email in emails:
                 responses = register_with_email_times(email, 10)
                 for response in responses:
@@ -343,7 +351,9 @@ def test_create_tokens_with_view(captured_emails):
 
     # assert everything was created in the registration view
     for email in emails:
-        verifications = OAuth2Verification.objects.filter(email=email).select_related('associated_application')
+        verifications = OAuth2Verification.objects.filter(email=email).select_related(
+            "associated_application"
+        )
         assert verifications.count() == 10
         assert OAuth2Registration.objects.filter(email=email).count() == 10
         for verification in verifications:
@@ -352,10 +362,17 @@ def test_create_tokens_with_view(captured_emails):
     call_resendoauthverification(dry_run=False)
 
     for email in emails:
-        verifications = OAuth2Verification.objects.filter(email=email).select_related('associated_application')
+        verifications = OAuth2Verification.objects.filter(email=email).select_related(
+            "associated_application"
+        )
         assert verifications.count() == 1
         assert OAuth2Registration.objects.filter(email=email).count() == 1
         for verification in verifications:
             assert verification.associated_application is not None
 
-        assert ThrottledApplication.objects.filter(name__contains=f"{email}'s sweet app").count() == 1
+        assert (
+            ThrottledApplication.objects.filter(
+                name__contains=f"{email}'s sweet app"
+            ).count()
+            == 1
+        )


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #689 by @AetherUnbound  

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Adds a new command to run for resending verification emails. Note: I haven't written unit tests for this but I need to stop working on this for the day and come back to it tomorrow. Just wanted to get a draft up early.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
I tried to write comprehensive unit tests. If you notice a missing branch please let me know so I can add additional tests.

You can test this on your local API (though I'm hoping the unit tests are sufficient) by setting the email backend to SMTP in your API settings without filling in the SMTP server information and then making some registration requests with multiple application names. Use a mix of the same email and different emails. This will cause the verifications to be completed, but because we haven't filled in the SMTP server information, it will fail to send the email (which is what was happening in production).

Then switch your settings back to the Console email backend and run the management command. You should see some helpful logs throughout the way, but also you'll see the emails that _would_ be sent pop into the console. It will look like this:

```
Content-Type: text/plain; charset="utf-8"
MIME-Version: 1.0
Content-Transfer-Encoding: 7bit
Subject: Verify your API credentials
From: 
To: user@example.com
Date: Thu, 12 May 2022 09:20:50 -0000
Message-ID: <165234725049.145.11337592980239670284@fa90ab837821>


The Openverse API OAuth2 email verification process has recently been fixed.
We have detected that you attempted to register an application using this email.

To verify your Openverse API credentials, click on the following link:

https://api.openverse.engineering//v1/auth_tokens/verify/<token redacted>

If you believe you received this message in error, please disregard it.

-------------------------------------------------------------------------------
Content-Type: text/plain; charset="utf-8"
MIME-Version: 1.0
Content-Transfer-Encoding: 7bit
Subject: Verify your API credentials
From: 
To: user@example.net
Date: Thu, 12 May 2022 09:20:50 -0000
Message-ID: <165234725049.145.2282716428617802226@fa90ab837821>


The Openverse API OAuth2 email verification process has recently been fixed.
We have detected that you attempted to register an application using this email.

To verify your Openverse API credentials, click on the following link:

https://api.openverse.engineering//v1/auth_tokens/verify/<token redacted>

If you believe you received this message in error, please disregard it.

-------------------------------------------------------------------------------
The following applications had email verifications sent.                                         

Application name: My amazing project
Cleaned related application count: 2
Cleaned related verification count: 0
Cleaned related registration count: 2


Application name: My amazing project5
Cleaned related application count: 0
Cleaned related verification count: 0
Cleaned related registration count: 0
```

To run the command:

For a dry run:
```
just dj resendoauthverification
```

For an actual run:
```
just dj resendoauthverification --no-dry_run
```

Note that the non-dry run requires you to input exactly `YES` as the response. Any other input including `yes` will not be accepted.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
