### PR TITLE
Add AudioReports to the Django admin

### DIFF
--- a/api/catalog/api/admin.py
+++ b/api/catalog/api/admin.py
@@ -11,7 +11,7 @@ from catalog.api.models import (
 )
 
 
-class AbstractMediaReportAdmin(admin.ModelAdmin):
+class MediaReportAdmin(admin.ModelAdmin):
     list_filter = ("status", "reason")
     list_display_links = ("status",)
     search_fields = ("description", "identifier")
@@ -38,12 +38,12 @@ class AbstractMediaReportAdmin(admin.ModelAdmin):
 
 
 @admin.register(AudioReport)
-class AudioReportAdmin(AbstractMediaReportAdmin):
+class AudioReportAdmin(MediaReportAdmin):
     list_display = ("reason", "status", "audio_url", "description", "created_at")
 
 
 @admin.register(ImageReport)
-class ImageReportAdmin(AbstractMediaReportAdmin):
+class ImageReportAdmin(MediaReportAdmin):
     list_display = ("reason", "status", "image_url", "description", "created_at")
 
 

--- a/api/catalog/api/admin.py
+++ b/api/catalog/api/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 
 from catalog.api.models import (
     PENDING,
+    AudioReport,
     ContentProvider,
     DeletedImage,
     ImageReport,
@@ -10,20 +11,20 @@ from catalog.api.models import (
 )
 
 
-@admin.register(ImageReport)
-class ImageReportAdmin(admin.ModelAdmin):
-    list_display = ("reason", "status", "image_url", "description", "created_at")
+class AbstractMediaReportAdmin(admin.ModelAdmin):
     list_filter = ("status", "reason")
     list_display_links = ("status",)
     search_fields = ("description", "identifier")
     actions = None
+
+    class Meta:
+        abstract = True
 
     def get_readonly_fields(self, request, obj=None):
         if obj is None:
             return []
         always_readonly = [
             "reason",
-            "image_url",
             "description",
             "identifier",
             "created_at",
@@ -34,6 +35,16 @@ class ImageReportAdmin(admin.ModelAdmin):
             status_readonly = ["status"]
             status_readonly.extend(always_readonly)
             return status_readonly
+
+
+@admin.register(AudioReport)
+class AudioReportAdmin(AbstractMediaReportAdmin):
+    list_display = ("reason", "status", "audio_url", "description", "created_at")
+
+
+@admin.register(ImageReport)
+class ImageReportAdmin(AbstractMediaReportAdmin):
+    list_display = ("reason", "status", "image_url", "description", "created_at")
 
 
 @admin.register(MatureImage)

--- a/api/catalog/api/admin.py
+++ b/api/catalog/api/admin.py
@@ -17,9 +17,6 @@ class MediaReportAdmin(admin.ModelAdmin):
     search_fields = ("description", "identifier")
     actions = None
 
-    class Meta:
-        abstract = True
-
     def get_readonly_fields(self, request, obj=None):
         if obj is None:
             return []


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Related to https://github.com/WordPress/openverse-catalog/issues/354

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
When an image is reported by a user through the `Report Content` feature, the reports become available for review in the `Image reports` admin page (http://localhost:8000/admin/api/imagereport/). When an audio file is reported, a similar report is created in the DB, but it isn't easily accessible through the Django Admin.

This PR adds an `Audio reports` admin page. It pulls out the existing code into an abstract MediaReportAdmin that can be used as additional models are added.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Visit both [Image](http://localhost:8000/admin/api/imagereport/) and [Audio](http://localhost:8000/admin/api/audioreport/) report admin pages and verify they work as normal (described below).

If you don't have any Image or Audio reports, you'll probably want to make some sample data. You can do this locally by going to the list view (eg `localhost:8000/v1/images`) and grabbing the id for a couple of the listed records, then POSTing a report (eg `localhost:8000/v1/<id>/report`). The process is the same for audio.

* You should see all the relevant fields on the main admin page
* You should be able to filter by status or reason
* You should be able to search by description and identifier
* When you click on the `status` for a row, you should be taken to its update page
    * If the `status` is `pending_review`, you should be able to edit the `status` field; if not, it should not be editable. No other fields should be editable in any case.
    * Test that you can save

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
