### PR TITLE
Fix issue due to `page_query_param` not being a string

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -142,6 +142,10 @@ jobs:
       - name: Start API, ingest and index test data
         run: just init
 
+      - name: Smoke test ReDoc site
+        run: |
+          curl --fail 'http://localhost:8000/v1/?format=openapi'
+
       - name: Run API tests
         run: just api-test
 

--- a/api/catalog/custom_auto_schema.py
+++ b/api/catalog/custom_auto_schema.py
@@ -4,6 +4,14 @@ from drf_yasg.utils import filter_none, force_real_str
 
 
 class CustomAutoSchema(SwaggerAutoSchema):
+    def get_pagination_parameters(self):
+        """
+        Since the pagination params are a part of the ``MediaSearchRequestSerializer``,
+        they need not be added again as pagination params.
+        """
+
+        return []
+
     def get_operation(self, operation_keys=None):
         operation_keys = operation_keys or self.operation_keys
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #722 by @AetherUnbound 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR fixes an error introduced in #699 that prevented the ReDoc pages from showing up. This is because the value of the field `page_query_param` is expected to be a string.

By setting pagination params to an empty list, this problem goes away.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
0. Check out the PR and start the server.
1. Visit ReDoc at `http://localhost:8000/v1`.
2. See the pages without any errors.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
