### PR TITLE
Make thumbnail link null for audio files without artwork

### DIFF
--- a/api/catalog/api/serializers/audio_serializers.py
+++ b/api/catalog/api/serializers/audio_serializers.py
@@ -135,6 +135,17 @@ class AudioSerializer(AudioHyperlinksSerializer, MediaSerializer):
             obj = Audio.objects.get(identifier=obj.identifier)
         return obj.get_waveform()
 
+    def to_representation(self, instance):
+        # Get the original representation
+        output = super().to_representation(instance)
+
+        if isinstance(instance, Hit):
+            audio = Audio.objects.get(identifier=instance.identifier)
+            if not audio.thumbnail:
+                output["thumbnail"] = None
+
+        return output
+
 
 class AudioSearchSerializer(MediaSearchSerializer):
     """

--- a/api/catalog/api/serializers/audio_serializers.py
+++ b/api/catalog/api/serializers/audio_serializers.py
@@ -140,6 +140,7 @@ class AudioSerializer(AudioHyperlinksSerializer, MediaSerializer):
         output = super().to_representation(instance)
 
         if isinstance(instance, Hit):
+            # TODO: Remove when updating ES indexes
             audio = Audio.objects.get(identifier=instance.identifier)
             if not audio.thumbnail:
                 output["thumbnail"] = None

--- a/api/test/audio_integration_test.py
+++ b/api/test/audio_integration_test.py
@@ -81,6 +81,14 @@ def test_audio_thumb(audio_fixture):
     thumb(audio_fixture)
 
 
+def test_audio_without_thumb():
+    """The first audio of this search should not have a thumbnail."""
+    resp = requests.get(f"{API_URL}/v1/audio?q=zaus&filter_dead=false")
+    assert resp.status_code == 200
+    parsed = json.loads(resp.text)
+    assert parsed["results"][0]["thumbnail"] is None
+
+
 def test_audio_thumb_compression(audio_fixture):
     thumb_compression(audio_fixture)
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #528 by @zackkrida.
Should also fix WordPress/openverse-frontend#1475

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Adds a check to the `AudioSerializer` if the underlying audio row has artwork and removes the link in the case is not found. I believe we should make sure the cover of the album (if exists) is duplicated in each track if that track does not have its own artwork. In fact, I find it rare the case where the audio will have a different cover than their album.

This also seems to be the common case with our current live data, the artwork of the `audio_set` will never be required unless you are watching at the `audio_set` directly.

```sql
-- Audio with thumbnail & audio set
 SELECT COUNT(id) FROM audio
 WHERE thumbnail IS NOT NULL AND audio_set_foreign_identifier IS NOT NULL;
 
+-------+
| count |
|-------|
| 0     |
+-------+
SELECT 1
Time: 0.179s


-- Audio with thumbnail & without audio set
 SELECT COUNT(id) FROM audio
 WHERE thumbnail IS NOT NULL AND audio_set_foreign_identifier IS NULL;
 
+-------+
| count |
|-------|
| 89138 |
+-------+
SELECT 1
Time: 0.179s


-- Audio without thumbnail & with audio set
 SELECT COUNT(id) FROM audio
 WHERE thumbnail IS NULL AND audio_set_foreign_identifier IS NOT NULL;
 
+-------+
| count |
|-------|
| 0     |
+-------+
SELECT 1
Time: 0.177s
```

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Find an audio row without a thumbnail in the database and check if is null in the `audio_detail` response.
Try with this search for the current data sample:
```
localhost:8000/v1/audio?q=zaus&filter_dead=false
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
