### PR TITLE
Fix search when no filters are applied

### DIFF
--- a/api/catalog/api/controllers/elasticsearch/search.py
+++ b/api/catalog/api/controllers/elasticsearch/search.py
@@ -9,6 +9,7 @@ from django.conf import settings
 
 from elasticsearch.exceptions import RequestError
 from elasticsearch_dsl import Q, Search
+from elasticsearch_dsl.query import EMPTY_QUERY
 from elasticsearch_dsl.response import Hit
 
 from catalog.api.controllers.elasticsearch.utils import (
@@ -151,7 +152,7 @@ def perform_search(
         rank_queries = []
         for field, boost in feature_boost.items():
             rank_queries.append(Q("rank_feature", field=field, boost=boost))
-        s.query = Q("bool", must=s.query, should=rank_queries)
+        s.query = Q("bool", must=s.query or EMPTY_QUERY, should=rank_queries)
 
     # Use highlighting to determine which fields contribute to the selection of
     # top results.


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #728 by @AetherUnbound 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
We were getting 500 errors when attempting to filter by mature content: http://localhost:8000/v1/images/?mature=true

The problem is caused by [this line](https://github.com/WordPress/openverse-api/blob/main/api/catalog/api/controllers/elasticsearch/search.py#L154), which attempts to append the `rank_queries` to the query we've built so far:
```
s.query = Q("bool", must=s.query, should=rank_queries)
```

The problem is that when we filter by `mature=true` and _no other filters_, no query has been built[^1]. That's because we don't actually add a Query when `mature=true` is passed as a query param (ie we treat this as "return mature results _as well_ ", rather than "return _only_ mature results"). 
* For this reason, you can actually filter by `mature=true` as long as you also pass some other filter (ie `?mature=true&category=illustration` works).
* All other searches work because we always [append a Query](https://github.com/WordPress/openverse-api/blob/main/api/catalog/api/controllers/elasticsearch/search.py#L112) to exclude mature content if `mature=false` is passed or if the param is omitted entirely

Fun fact if you're interested: This used to work because every search would always append a query for `excluded_providers`, even if the list of excluded providers was empty (eg `{‘query': {'bool': {'filter': [{'bool': {'must_not': [{'terms': {'provider': []}}]}}]}}}`). This was cleaned up in #699 as it certainly should've been 😄 but happened to expose the edge case.

The solution is to explicitly fall back to an EMPTY_QUERY.


[^1]: This is a simplified explanation. `s.query` is a `QueryProxy` ([source](https://github.com/elastic/elasticsearch-dsl-py/blob/dd0101042ecc0256e02e72182d6f4c62aa7cf365/elasticsearch_dsl/search.py#L37)), and it is the underlying wrapped query that is not initialized. The consequence is that `s.query` is not None but _is_ Falsy

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

You can verify the bug on `main` by navigating to http://localhost:8000/v1/images/?mature=true and seeing the 500 error. Pull this branch and refresh; you should see results and no error.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
