### PR TITLE
Ensure that the docs cleanup step only runs on PRs that have permission

### DIFF
--- a/.github/workflows/pr_closed.yml
+++ b/.github/workflows/pr_closed.yml
@@ -9,6 +9,8 @@ jobs:
   clean-gh-pages:
     name: Clean API developer docs preview
     runs-on: ubuntu-latest
+    # Check if the event is not triggered by a fork or dependabot
+    if: github.event_name == 'pull_request' && github.repository_owner == 'WordPress' && github.actor != 'dependabot[bot]'
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Follow up on #747, additionally for the action that runs when a PR is closed. This was failing for the dependabot PRs: [[1]](https://github.com/WordPress/openverse-api/runs/6816938250?check_suite_focus=true) [[2]](https://github.com/WordPress/openverse-api/runs/6815499390?check_suite_focus=true) [[3]](https://github.com/WordPress/openverse-api/runs/6801480540?check_suite_focus=true)

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
We'll have to see! It worked for the publish step though so I suspect it should work for the close PR step :slightly_smiling_face:

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
