### PR TITLE
Log each index & constraint step

### DIFF
--- a/ingestion_server/test/integration_test.py
+++ b/ingestion_server/test/integration_test.py
@@ -296,7 +296,7 @@ class TestIngestion(unittest.TestCase):
         log_output = compose_path.parent / "ingestion_logs.txt"
         with log_output.open("w") as file:
             subprocess.run(
-                ["docker-compose", "-f", compose_path.name, "logs"],
+                ["docker-compose", "-f", compose_path.name, "logs", "--no-color"],
                 cwd=compose_path.parent,
                 check=True,
                 stderr=subprocess.STDOUT,


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #752 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR splits the index application & constraint remapping steps into separate, loggable executions so that we can determine how long each step takes during the data refresh.

I also improved the output of the integration tests a bit by removing colors that don't show up well in things that aren't a terminal.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. Run `just ing-testlocal`
1. Open `ingestionserver/test/ingestion_logs.txt`
1. Observe the following lines (or similar) for each of the models:


```
integration_ingestion_server_1  | 2022-06-10 23:53:48,940 INFO ingest.py:348 - Copying finished! Recreating database indices...
integration_ingestion_server_1  | 2022-06-10 23:53:48,943 INFO ingest.py:353 - Running: CREATE UNIQUE INDEX temp_import_api_audioset_url_key ON public.temp_import_audioset USING btree (url)
integration_ingestion_server_1  | 2022-06-10 23:53:48,949 INFO ingest.py:353 - Running: CREATE UNIQUE INDEX temp_import_unique_foreign_identifier_provider ON public.temp_import_audioset USING btree (foreign_identifier, provider)
integration_ingestion_server_1  | 2022-06-10 23:53:48,954 INFO ingest.py:353 - Running: CREATE INDEX temp_import_api_audioset_foreign_identifier_28c1db59 ON public.temp_import_audioset USING btree (foreign_identifier)
integration_ingestion_server_1  | 2022-06-10 23:53:48,964 INFO ingest.py:353 - Running: CREATE INDEX temp_import_api_audioset_foreign_identifier_28c1db59_like ON public.temp_import_audioset USING btree (foreign_identifier varchar_pattern_ops)
integration_ingestion_server_1  | 2022-06-10 23:53:48,969 INFO ingest.py:353 - Running: CREATE INDEX temp_import_api_audioset_url_200f9fb4_like ON public.temp_import_audioset USING btree (url varchar_pattern_ops)
integration_ingestion_server_1  | 2022-06-10 23:53:48,974 INFO ingest.py:353 - Running: CREATE INDEX temp_import_audioset_provider_cc061f30 ON public.temp_import_audioset USING btree (provider)
integration_ingestion_server_1  | 2022-06-10 23:53:48,980 INFO ingest.py:353 - Running: CREATE INDEX temp_import_audioset_provider_cc061f30_like ON public.temp_import_audioset USING btree (provider varchar_pattern_ops)
integration_ingestion_server_1  | 2022-06-10 23:53:48,986 INFO ingest.py:355 - Done creating indices! Remapping constraints...
integration_ingestion_server_1  | 2022-06-10 23:53:48,989 INFO ingest.py:362 - Running: ALTER TABLE "audioset" DROP CONSTRAINT "api_audioset_url_key"
integration_ingestion_server_1  | 2022-06-10 23:53:48,990 INFO ingest.py:362 - Running: ALTER TABLE "audioset" ADD UNIQUE (url)
integration_ingestion_server_1  | 2022-06-10 23:53:48,995 INFO ingest.py:362 - Running: ALTER TABLE "audioset" DROP CONSTRAINT "unique_foreign_identifier_provider"
integration_ingestion_server_1  | 2022-06-10 23:53:48,996 INFO ingest.py:362 - Running: ALTER TABLE "audioset" ADD UNIQUE (foreign_identifier, provider)
integration_ingestion_server_1  | 2022-06-10 23:53:49,002 INFO ingest.py:364 - Done remapping constraints! Going live with new table...
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
