### PR TITLE
Make thumbnail link null for in audio detail endpoint when it doesn't exist

### DIFF
--- a/api/catalog/api/serializers/audio_serializers.py
+++ b/api/catalog/api/serializers/audio_serializers.py
@@ -145,6 +145,9 @@ class AudioSerializer(AudioHyperlinksSerializer, MediaSerializer):
             if not audio.thumbnail:
                 output["thumbnail"] = None
 
+        if isinstance(instance, Audio) and not instance.thumbnail:
+            output["thumbnail"] = None
+
         return output
 
 

--- a/api/catalog/api/serializers/audio_serializers.py
+++ b/api/catalog/api/serializers/audio_serializers.py
@@ -138,14 +138,13 @@ class AudioSerializer(AudioHyperlinksSerializer, MediaSerializer):
     def to_representation(self, instance):
         # Get the original representation
         output = super().to_representation(instance)
+        audio = instance
 
         if isinstance(instance, Hit):
-            # TODO: Remove when updating ES indexes
+            # TODO: Remove this DB query when updating ES index
             audio = Audio.objects.get(identifier=instance.identifier)
-            if not audio.thumbnail:
-                output["thumbnail"] = None
 
-        if isinstance(instance, Audio) and not instance.thumbnail:
+        if isinstance(audio, Audio) and not audio.thumbnail:
             output["thumbnail"] = None
 
         return output

--- a/api/test/audio_integration_test.py
+++ b/api/test/audio_integration_test.py
@@ -90,7 +90,7 @@ def test_audio_detail_without_thumb():
 
 def test_audio_search_without_thumb():
     """The first audio of this search should not have a thumbnail."""
-    resp = requests.get(f"{API_URL}/v1/audio?q=zaus&filter_dead=false")
+    resp = requests.get(f"{API_URL}/v1/audio/?q=zaus&filter_dead=false")
     assert resp.status_code == 200
     parsed = json.loads(resp.text)
     assert parsed["results"][0]["thumbnail"] is None

--- a/api/test/audio_integration_test.py
+++ b/api/test/audio_integration_test.py
@@ -81,7 +81,14 @@ def test_audio_thumb(audio_fixture):
     thumb(audio_fixture)
 
 
-def test_audio_without_thumb():
+def test_audio_detail_without_thumb():
+    resp = requests.get(f"{API_URL}/v1/audio/00289ffb-0c74-4008-8388-0bf6d8173dee")
+    assert resp.status_code == 200
+    parsed = json.loads(resp.text)
+    assert parsed["thumbnail"] is None
+
+
+def test_audio_search_without_thumb():
     """The first audio of this search should not have a thumbnail."""
     resp = requests.get(f"{API_URL}/v1/audio?q=zaus&filter_dead=false")
     assert resp.status_code == 200


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes WordPress/openverse-frontend#1475 by @krysal

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
As the title says, omit the thumbnail links for those audio files without a cover.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
You can try querying to find audio without a thumbnail and then make the request to confirm the link is not present in the response.

```sql
-- Pick an identifier from these results
SELECT identifier FROM audio WHERE thumbnail IS NULL;
```

```sh
# Make a request
curl http://localhost:8000/v1/audio/<identifier>
```

You can also run both project, the API and the frontend, and confirm it does show the default og image.

<img width="374" alt="CleanShot 2022-06-21 at 10 23 59@2x" src="https://user-images.githubusercontent.com/9145885/174823644-93851624-5f60-4c4b-b728-08de17778dee.png">


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
