### PR TITLE
Fix invalid UUID breaking related images query

### DIFF
--- a/api/catalog/api/views/media_views.py
+++ b/api/catalog/api/views/media_views.py
@@ -116,6 +116,9 @@ class MediaViewSet(ReadOnlyModelViewSet):
             self.paginator.page_size = 10
         except ValueError as e:
             raise get_api_exception(getattr(e, "message", str(e)))
+        # If there are no hits in the search controller
+        except IndexError:
+            raise get_api_exception("Could not find items.", 404)
 
         serializer = self.get_serializer(results, many=True)
         return self.get_paginated_response(serializer.data)

--- a/api/test/api_live_integration.py
+++ b/api/test/api_live_integration.py
@@ -446,6 +446,13 @@ def test_page_consistency_removing_dead_links(search_without_dead_links):
     assert no_duplicates(ids)
 
 
+def test_related_does_not_break():
+    response = requests.get(
+        f"{API_URL}/image/related/000000000000000000000000000000000000", verify=False
+    )
+    assert response.status_code == 404
+
+
 @pytest.fixture
 def related_factory():
     """


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Related to #729 by @AetherUnbound 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR uses @krysal 's [suggestion](https://github.com/WordPress/openverse-api/issues/729#issuecomment-1163336180) to add an IndexError handling for when there are no `hits` in the search controller:
https://github.com/WordPress/openverse-api/blob/7414174a16ba4cbd6af70773ce6d19b92b0e96de/api/catalog/api/controllers/search_controller.py#L344

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
On main, if you go to `http://localhost:8000/v1/images/000000000000000000000000000000000000/related/`, you would get a 500 error.
On this branch, you should get a 404.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
