### PR TITLE
License validation does not work correctly for non-lower-case strings #740

### DIFF
--- a/api/catalog/api/serializers/media_serializers.py
+++ b/api/catalog/api/serializers/media_serializers.py
@@ -130,7 +130,7 @@ class MediaSearchRequestSerializer(serializers.Serializer):
                 raise serializers.ValidationError(
                     f"License '{_license}' does not exist."
                 )
-        return value
+        return value.lower()
 
     @staticmethod
     def validate_license_type(value):

--- a/api/catalog/api/serializers/media_serializers.py
+++ b/api/catalog/api/serializers/media_serializers.py
@@ -130,6 +130,7 @@ class MediaSearchRequestSerializer(serializers.Serializer):
                 raise serializers.ValidationError(
                     f"License '{_license}' does not exist."
                 )
+        # lowers the case of the value before returning
         return value.lower()
 
     @staticmethod

--- a/api/test/audio_integration_test.py
+++ b/api/test/audio_integration_test.py
@@ -20,6 +20,7 @@ from test.media_integration import (
     thumb_compression,
     thumb_full_size,
     thumb_webp,
+    license_filter_case_insensitivity,
 )
 
 import pytest
@@ -110,3 +111,7 @@ def test_audio_thumb_full_size(audio_fixture):
 
 def test_audio_report(audio_fixture):
     report("audio", audio_fixture)
+
+def test_audio_license_filter_case_insensitivity():
+    license_filter_case_insensitivity("audio")
+    

--- a/api/test/audio_integration_test.py
+++ b/api/test/audio_integration_test.py
@@ -112,6 +112,6 @@ def test_audio_thumb_full_size(audio_fixture):
 def test_audio_report(audio_fixture):
     report("audio", audio_fixture)
 
+
 def test_audio_license_filter_case_insensitivity():
     license_filter_case_insensitivity("audio")
-    

--- a/api/test/audio_integration_test.py
+++ b/api/test/audio_integration_test.py
@@ -7,6 +7,7 @@ import json
 from test.constants import API_URL
 from test.media_integration import (
     detail,
+    license_filter_case_insensitivity,
     report,
     search,
     search_all_excluded,
@@ -20,7 +21,6 @@ from test.media_integration import (
     thumb_compression,
     thumb_full_size,
     thumb_webp,
-    license_filter_case_insensitivity,
 )
 
 import pytest

--- a/api/test/image_integration_test.py
+++ b/api/test/image_integration_test.py
@@ -20,6 +20,9 @@ from test.media_integration import (
     thumb_compression,
     thumb_full_size,
     thumb_webp,
+    license_filter_case_insensitivity,
+    
+
 )
 from urllib.parse import urlencode
 
@@ -127,3 +130,7 @@ def test_oembed_endpoint_for_xml():
         xml_tree.find("license_url").text
         == "https://creativecommons.org/licenses/by/2.0/"
     )
+
+def test_image_license_filter_case_insensitivity():
+    license_filter_case_insensitivity("images")
+    

--- a/api/test/image_integration_test.py
+++ b/api/test/image_integration_test.py
@@ -131,6 +131,6 @@ def test_oembed_endpoint_for_xml():
         == "https://creativecommons.org/licenses/by/2.0/"
     )
 
+
 def test_image_license_filter_case_insensitivity():
     license_filter_case_insensitivity("images")
-    

--- a/api/test/image_integration_test.py
+++ b/api/test/image_integration_test.py
@@ -8,6 +8,7 @@ import xml.etree.ElementTree as ET
 from test.constants import API_URL
 from test.media_integration import (
     detail,
+    license_filter_case_insensitivity,
     report,
     search,
     search_all_excluded,
@@ -20,7 +21,6 @@ from test.media_integration import (
     thumb_compression,
     thumb_full_size,
     thumb_webp,
-    license_filter_case_insensitivity,
 )
 from urllib.parse import urlencode
 

--- a/api/test/image_integration_test.py
+++ b/api/test/image_integration_test.py
@@ -21,8 +21,6 @@ from test.media_integration import (
     thumb_full_size,
     thumb_webp,
     license_filter_case_insensitivity,
-    
-
 )
 from urllib.parse import urlencode
 

--- a/api/test/media_integration.py
+++ b/api/test/media_integration.py
@@ -163,5 +163,4 @@ def report(media_type, fixture):
 def license_filter_case_insensitivity(media_type):
     response = requests.get(f"{API_URL}/v1/{media_type}?license=bY", verify=False)
     parsed = json.loads(response.text)
-    
-    assert parsed["result_count"] >0
+    assert parsed["result_count"] > 0

--- a/api/test/media_integration.py
+++ b/api/test/media_integration.py
@@ -158,3 +158,10 @@ def report(media_type, fixture):
     assert response.status_code == 201
     data = json.loads(response.text)
     assert data["identifier"] == test_id
+
+
+def license_filter_case_insensitivity(media_type):
+    response = requests.get(f"{API_URL}/v1/{media_type}?license=bY", verify=False)
+    parsed = json.loads(response.text)
+    
+    assert parsed["result_count"] >0


### PR DESCRIPTION
## Fixes
Fixes #740  by @obulat 

## Description
This PR fixes the issue of the case sensitivity of the license filter. It only required a tiny change in the serialzier.  

## Testing Instructions
on main, Both endpoints `http://localhost:8000/v1/images?license=cC0,By` and `http://localhost:8000/v1/images?license=cc0,by` returns the same output

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
