### PR TITLE
Use force_orphan to prevent gh-pages branch history from ballooning repo size

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -278,14 +278,29 @@ jobs:
           docker load --input /tmp/ingestion_server/ingestion_server.tar
 
       - name: Make developer docs
-        run: just sphinx-make
+        run: |
+          just sphinx-make
+          mv ./api/build/html /tmp/gh-pages
+
+      - uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+      
+      - name: Preserve previews
+        run: mv _preview /tmp/gh-pages/_preview
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501 # v3.7.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./api/build/html/
-          keep_files: true
+          publish_dir: /tmp/gh-pages
+          force_orphan: true
+
+      - name: Checkout branch again to enable cleaning
+        if: always()
+        uses: actions/checkout@v3
+        with:
+          ref: main
 
   docs-preview:
     name: Publish preview of developer docs for the branch
@@ -336,15 +351,37 @@ jobs:
           docker load --input /tmp/ingestion_server/ingestion_server.tar
 
       - name: Build docs
-        run: just sphinx-make
+        run: |
+          just sphinx-make
+          mv ./api/build/html /tmp/preview
+      
+      # Otherwise we end up with any extra stuff not git-ignored in the gh-pages branch
+      - name: Recreate working directory to avoid supurflouous files
+        run: |
+          cd ..
+          rm -rf openverse-api
+          mkdir openverse-api
+
+      - uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+
+      - name: Merge preview with existing gh-pages
+        run: |
+          cd ..
+          cp -r ./openverse-api /tmp/gh-pages
+          # trash the existing preview folder and replace it with the newly generated one
+          # if the preview hasn't been pushed yet this will still exit(0)
+          rm -rf /tmp/gh-pages/_preview/${{ github.event.pull_request.number }}
+          mv /tmp/preview /tmp/gh-pages/_preview/${{ github.event.pull_request.number }}
+          cd openverse-api
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./api/build/html/
-          destination_dir: _preview/${{ github.event.pull_request.number }}
-          keep_files: true
+          publish_dir: /tmp/gh-pages
+          force_orphan: true
 
       - uses: peter-evans/find-comment@v2
         id: final-preview-comment
@@ -364,3 +401,7 @@ jobs:
             Please note that GitHub pages takes a little time to deploy newly pushed code, if the links above don't work or you see old versions, wait 5 minutes and try again.
 
             You can check [the GitHub pages deployment action list](https://github.com/WordPress/openverse-api/actions/workflows/pages/pages-build-deployment) to see the current status of the deployments.
+
+      - name: Checkout branch again to enable cleaning
+        uses: actions/checkout@v3
+        if: always()

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -353,6 +353,7 @@ jobs:
       - name: Build docs
         run: |
           just sphinx-make
+          sudo chown $USER:$USER -R ./api
           mv ./api/build/html /tmp/preview
 
       # Otherwise we end up with any extra stuff not git-ignored in the gh-pages branch

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -357,7 +357,7 @@ jobs:
           mv ./api/build/html /tmp/preview
 
       # Otherwise we end up with any extra stuff not git-ignored in the gh-pages branch
-      - name: Recreate working directory to avoid supurflouous files
+      - name: Recreate working directory to avoid superfluous files
         run: |
           cd ..
           sudo rm -rf openverse-api

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -285,7 +285,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: gh-pages
-      
+
       - name: Preserve previews
         run: mv _preview /tmp/gh-pages/_preview
 
@@ -354,7 +354,7 @@ jobs:
         run: |
           just sphinx-make
           mv ./api/build/html /tmp/preview
-      
+
       # Otherwise we end up with any extra stuff not git-ignored in the gh-pages branch
       - name: Recreate working directory to avoid supurflouous files
         run: |

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -353,7 +353,7 @@ jobs:
       - name: Build docs
         run: |
           just sphinx-make
-          sudo chown $USER:$USER -R ./api
+          sudo chown "$USER:$USER" -R ./api
           mv ./api/build/html /tmp/preview
 
       # Otherwise we end up with any extra stuff not git-ignored in the gh-pages branch

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -359,7 +359,7 @@ jobs:
       - name: Recreate working directory to avoid supurflouous files
         run: |
           cd ..
-          rm -rf openverse-api
+          sudo rm -rf openverse-api
           mkdir openverse-api
 
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #817  by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Applies the same fixes and strategies from https://github.com/WordPress/openverse-frontend/pull/1574 to the API so that we stop keeping a useless history of the `gh-pages` branch.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Checkout the preview and make sure it works.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [N/A] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [N/A] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
