### PR TITLE
Only backfill dead links if at least one on first page was not dead

### DIFF
--- a/api/catalog/api/controllers/search_controller.py
+++ b/api/catalog/api/controllers/search_controller.py
@@ -44,6 +44,9 @@ def _paginate_with_dead_link_mask(
     Given a query, a page and page_size, return the start and end
     of the slice of results.
 
+    In almost all cases the ``DEAD_LINK_RATIO`` will effectively double
+    the page size (given the current configuration of 0.5).
+
     :param s: The elasticsearch Search object
     :param page_size: How big the page should be.
     :param page: The page number.
@@ -130,6 +133,10 @@ def _post_process_results(
     if filter_dead:
         query_hash = get_query_hash(s)
         validate_images(query_hash, start, results, to_validate)
+
+        if len(results) == 0:
+            # first page is all dead links
+            return []
 
         if len(results) < page_size:
             end += int(end / 2)

--- a/api/test/dead_link_filter_test.py
+++ b/api/test/dead_link_filter_test.py
@@ -151,6 +151,8 @@ def test_dead_link_filtering_all_dead_links(
     res_json = response.json()
 
     assert len(res_json["results"]) == expected_result_count
+    if expected_result_count == 0:
+        assert res_json["result_count"] == 0
 
 
 @pytest.fixture

--- a/api/test/dead_link_filter_test.py
+++ b/api/test/dead_link_filter_test.py
@@ -7,7 +7,6 @@ import requests
 from fakeredis import FakeRedis
 
 from catalog.api.controllers.search_controller import DEAD_LINK_RATIO
-
 from catalog.api.utils.pagination import MAX_TOTAL_PAGE_COUNT
 
 

--- a/api/test/dead_link_filter_test.py
+++ b/api/test/dead_link_filter_test.py
@@ -1,23 +1,51 @@
 from test.constants import API_URL
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 import pytest
 import requests
+from fakeredis import FakeRedis
+
+from catalog.api.controllers.search_controller import DEAD_LINK_RATIO
 
 from catalog.api.utils.pagination import MAX_TOTAL_PAGE_COUNT
 
 
-def _patch_redis():
-    def redis_mget(keys, *_, **__):
-        """
-        Patch for ``redis.mget`` used by ``validate_images`` to use validity
-        information from the cache
-        """
-        return [None] * len(keys)
+@pytest.fixture(autouse=True)
+def redis(monkeypatch) -> FakeRedis:
+    fake_redis = FakeRedis()
 
-    mock_conn = MagicMock()
-    mock_conn.mget = MagicMock(side_effect=redis_mget)
-    return patch("django_redis.get_redis_connection", return_value=mock_conn)
+    def get_redis_connection(*args, **kwargs):
+        return fake_redis
+
+    monkeypatch.setattr(
+        "catalog.api.utils.dead_link_mask.get_redis_connection", get_redis_connection
+    )
+    monkeypatch.setattr("django_redis.get_redis_connection", get_redis_connection)
+
+    yield fake_redis
+    fake_redis.client().close()
+
+
+@pytest.fixture
+def unique_query_hash(redis, monkeypatch):
+    def get_unique_hash(*args, **kwargs):
+        return str(uuid4())
+
+    monkeypatch.setattr(
+        "catalog.api.controllers.search_controller.get_query_hash", get_unique_hash
+    )
+
+
+@pytest.fixture
+def empty_validation_cache(monkeypatch):
+    def get_empty_cached_statuses(_, image_urls):
+        return [None] * len(image_urls)
+
+    monkeypatch.setattr(
+        "catalog.api.utils.validate_images._get_cached_statuses",
+        get_empty_cached_statuses,
+    )
 
 
 def _patch_grequests():
@@ -36,10 +64,29 @@ def _patch_grequests():
     return patch("grequests.map", side_effect=grequests_map)
 
 
+def patch_link_validation_dead_for_count(count):
+    total_res_count = 0
+
+    def grequests_map(reqs, *_, **__):
+        nonlocal total_res_count
+        """
+        Patch for ``grequests.map`` used by ``validate_images`` to filter
+        and remove dead links
+        """
+        responses = []
+        for idx in range(len(list(reqs))):
+            total_res_count += 1
+            mocked_res = MagicMock()
+            mocked_res.status_code = 404 if total_res_count <= count else 200
+            responses.append(mocked_res)
+        return responses
+
+    return patch("grequests.map", side_effect=grequests_map)
+
+
 @pytest.mark.django_db
-@_patch_redis()
 @_patch_grequests()
-def test_dead_link_filtering(mocked_map, _, client):
+def test_dead_link_filtering(mocked_map, client):
     path = "/v1/images/"
     query_params = {"q": "*", "page_size": 20}
 
@@ -67,7 +114,44 @@ def test_dead_link_filtering(mocked_map, _, client):
 
     res_1_ids = set(result["id"] for result in data_with_dead_links["results"])
     res_2_ids = set(result["id"] for result in data_without_dead_links["results"])
+    # In this case, both have 20 results as the dead link filter has "back filled" the
+    # pages of dead links. See the subsequent test for the case when this does not
+    # occur (i.e., when the entire first page of links is dead).
+    assert len(res_1_ids) == 20
+    assert len(res_2_ids) == 20
     assert bool(res_1_ids - res_2_ids)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("filter_dead", "page_size", "expected_result_count"),
+    (
+        (True, 20, 0),
+        (False, 20, 20),
+    ),
+)
+def test_dead_link_filtering_all_dead_links(
+    client,
+    filter_dead,
+    page_size,
+    expected_result_count,
+    unique_query_hash,
+    empty_validation_cache,
+):
+    path = "/v1/images/"
+    query_params = {"q": "*", "page_size": page_size}
+
+    with patch_link_validation_dead_for_count(page_size / DEAD_LINK_RATIO):
+        response = client.get(
+            path,
+            query_params | {"filter_dead": filter_dead},
+        )
+
+    assert response.status_code == 200
+
+    res_json = response.json()
+
+    assert len(res_json["results"]) == expected_result_count
 
 
 @pytest.fixture


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #855 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
If after validating dead links, there are zero results, assume any subsequent deeper paginations of the same query will not yield better returns. The lines changed is a lie: it's like 97% changes in the unit tests. The actual change required to make this work is two SLOC with some explanatory comments.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Check out the unit tests. To test this locally the best thing to do would be to use OpenSnitch or some other firewall to block outbound requests to Flickr. Then observe the logs and ensure that only a single query is sent to Elasticsearch. Note: this will be hard to do if on Linux with Docker as root (you'll need to mess with a bunch of iptables configurations). Instead, you can just modify the code to set the status code on the responses manually using this patch:

```diff
diff --git a/api/catalog/api/utils/validate_images.py b/api/catalog/api/utils/validate_images.py
index 6ad23f6f..c4dcbb42 100644
--- a/api/catalog/api/utils/validate_images.py
+++ b/api/catalog/api/utils/validate_images.py
@@ -58,7 +58,7 @@ def validate_images(query_hash, start_slice, results, image_urls):
         # Response didn't arrive in time. Try again later.
         else:
             status = -1
-        to_cache[cache_key] = status
+        to_cache[cache_key] = 404
 
     thirty_minutes = 60 * 30
     twenty_four_hours_seconds = 60 * 60 * 24
@@ -83,7 +83,7 @@ def validate_images(query_hash, start_slice, results, image_urls):
     for idx, url in enumerate(to_verify):
         cache_idx = to_verify[url]
         if verified[idx] is not None:
-            cached_statuses[cache_idx] = verified[idx].status_code
+            cached_statuses[cache_idx] = 404
         else:
             cached_statuses[cache_idx] = -1
```

Then you can make any request and all links will get cached as dead. You should get responses back that have empty results now from queries that previously gave back results with the local data (like `source=flickr`).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
