### PR TITLE
Do not 500 when upstream provider is unavailable

### DIFF
--- a/api/test/factory/models/image.py
+++ b/api/test/factory/models/image.py
@@ -1,0 +1,8 @@
+from test.factory.models.media import MediaFactory
+
+from catalog.api.models.image import Image
+
+
+class ImageFactory(MediaFactory):
+    class Meta:
+        model = Image

--- a/api/test/image_integration_test.py
+++ b/api/test/image_integration_test.py
@@ -20,7 +20,6 @@ from test.media_integration import (
     stats,
     thumb,
     thumb_compression,
-    thumb_error,
     thumb_full_size,
     thumb_webp,
     uuid_validation,
@@ -89,10 +88,6 @@ def test_image_thumb_webp(image_fixture):
 
 def test_image_thumb_full_size(image_fixture):
     thumb_full_size(image_fixture)
-
-
-def test_image_thumb_failure(image_fixture):
-    thumb_error(image_fixture)
 
 
 def test_audio_report(image_fixture):

--- a/api/test/image_integration_test.py
+++ b/api/test/image_integration_test.py
@@ -20,6 +20,7 @@ from test.media_integration import (
     stats,
     thumb,
     thumb_compression,
+    thumb_error,
     thumb_full_size,
     thumb_webp,
     uuid_validation,
@@ -88,6 +89,10 @@ def test_image_thumb_webp(image_fixture):
 
 def test_image_thumb_full_size(image_fixture):
     thumb_full_size(image_fixture)
+
+
+def test_image_thumb_failure(image_fixture):
+    thumb_error(image_fixture)
 
 
 def test_audio_report(image_fixture):

--- a/api/test/unit/views/media_views_test.py
+++ b/api/test/unit/views/media_views_test.py
@@ -1,0 +1,40 @@
+from test.factory.models.image import ImageFactory
+from unittest import mock
+from urllib.error import HTTPError
+
+from rest_framework.test import APIClient
+
+import pytest
+
+from catalog.api.models.image import Image
+
+
+@pytest.fixture
+def api_client() -> APIClient:
+    return APIClient()
+
+
+@pytest.fixture
+def image() -> Image:
+    return ImageFactory.create()
+
+
+@pytest.mark.django_db
+def test_thumb_error(api_client, image):
+    error = None
+
+    def urlopen_503_response(url, **kwargs):
+        nonlocal error
+        error = HTTPError(url, 503, "Bad error upstream whoops", {}, None)
+        raise error
+
+    with mock.patch(
+        "catalog.api.views.media_views.urlopen"
+    ) as urlopen_mock, mock.patch(
+        "catalog.api.views.media_views.capture_exception", autospec=True
+    ) as mock_capture_exception:
+        urlopen_mock.side_effect = urlopen_503_response
+        response = api_client.get(f"/v1/images/{image.identifier}/thumb/")
+
+    assert response.status_code == 424
+    mock_capture_exception.assert_called_once_with(error)


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #847 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Fixes the issue by returning a 424: https://httpstatus.in/424/

> The method could not be performed on the resource because the requested action depended on another action and that action failed.

This makes sense for this error because we're not encountering a problem ourselves, rather there is an issue with the dependency (the upstream provider).

Still capture the exception in Sentry so that it can be addressed and tracked.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Checkout this branch and `just down && just up` to get the fresh code running. Block a request to a provider using a firewall and see that 424 is returned. 

Check out the unit test. I tried to add it to the existing media integration suite but that wasn't possible because it didn't allow for mocking the `urlopen` function as that whole suite relies on `requests` instead of the django test client. It makes actual http requests to the running process which cannot be patched (as far as I can tell).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [N/A] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
