### PR TITLE
Extend valid link cache time to 30 days and make cache expiration times minimally configurable

### DIFF
--- a/api/catalog/api/utils/validate_images.py
+++ b/api/catalog/api/utils/validate_images.py
@@ -3,6 +3,7 @@ import time
 
 import django_redis
 import grequests
+from decouple import config
 
 from catalog.api.utils.dead_link_mask import get_query_mask, save_query_mask
 
@@ -16,6 +17,10 @@ CACHE_PREFIX = "valid:"
 def _get_cached_statuses(redis, image_urls):
     cached_statuses = redis.mget([CACHE_PREFIX + url for url in image_urls])
     return [int(b.decode("utf-8")) if b is not None else None for b in cached_statuses]
+
+
+def _get_expiry(status, default):
+    return config(f"LINK_VALIDATION_CACHE_EXPIRY__{status}", default=default, cast=int)
 
 
 def validate_images(query_hash, start_slice, results, image_urls):
@@ -69,14 +74,17 @@ def validate_images(query_hash, start_slice, results, image_urls):
         # Cache successful links for a day, and broken links for 120 days.
         if status == 200:
             logger.debug("healthy link " f"key={key} ")
-            pipe.expire(key, twenty_four_hours_seconds)
+            expiry = _get_expiry(200, twenty_four_hours_seconds)
         elif status == -1:
             logger.debug("no response from provider " f"key={key}")
             # Content provider failed to respond; try again in a short interval
-            pipe.expire(key, thirty_minutes)
+            expiry = _get_expiry(-1, thirty_minutes)
         else:
             logger.debug("broken link " f"key={key} ")
-            pipe.expire(key, twenty_four_hours_seconds * 120)
+            expiry = _get_expiry("DEFAULT", twenty_four_hours_seconds * 120)
+
+        pipe.expire(key, expiry)
+
     pipe.execute()
 
     # Merge newly verified results with cached statuses

--- a/api/catalog/api/utils/validate_images.py
+++ b/api/catalog/api/utils/validate_images.py
@@ -74,11 +74,11 @@ def validate_images(query_hash, start_slice, results, image_urls):
         # Cache successful links for a day, and broken links for 120 days.
         if status == 200:
             logger.debug("healthy link " f"key={key} ")
-            expiry = _get_expiry(200, twenty_four_hours_seconds)
+            expiry = _get_expiry(200, twenty_four_hours_seconds * 30)
         elif status == -1:
             logger.debug("no response from provider " f"key={key}")
             # Content provider failed to respond; try again in a short interval
-            expiry = _get_expiry(-1, thirty_minutes)
+            expiry = _get_expiry("_1", thirty_minutes)
         else:
             logger.debug("broken link " f"key={key} ")
             expiry = _get_expiry("DEFAULT", twenty_four_hours_seconds * 120)


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #867 by @obulat 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Makes the link validation cache expiration times minimally configurable and increases the valid link cache time to 30 days.

I have another patch that introduces more flexible configuration by status code, in case that is something we want to explore.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Checkout this branch and `just down && just up` to ensure you get the latest code. Smoke test the app around link validation and confirm that things are getting cached. You can do so by observing the log output. For example, a request to `/v1/images/` will output a bunch of warning logs about making insecure requests to staticflickr the first time but should not output any on the second request.

If you want to confirm the cache times more explicitly, you'll need to upgrade redis locally to version 7 so that you can use the `EXPIRETIME` command. To do this, update the `cache` image tag from `4.x.x` to `7`:

```diff
diff --git a/docker-compose.yml b/docker-compose.yml
index beed92cc..11ebea67 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       test: "pg_isready -U deploy -d openledger"
 
   cache:
-    image: redis:4.0.10
+    image: redis:7
     ports:
       - "6379:6379"
```

Then run `redis-cli` locally and try the following:

```
# copy one of these keys
> keys "valid*"
# find the status code cached for that link
> get "<copied key>"
# see the expire time set for the key
> expiretime "<copied key>"
```

expiretime returns the Unix timestamp from origin so you'll have to do some math to confirm that it matches your expectation based on when the key was inserted. To clear your local Redis, run `redis-cli flushall`. This is useful for trying this process a couple times to confirm it's working as expected.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
