### PR TITLE
Make link validation expiry maximally configurable

### DIFF
--- a/api/catalog/api/utils/validate_images.py
+++ b/api/catalog/api/utils/validate_images.py
@@ -88,11 +88,11 @@ def validate_images(query_hash, start_slice, results, image_urls):
         # Cache successful links for a day, and broken links for 120 days.
         if status == 200:
             logger.debug("healthy link " f"key={key} ")
-            expiry = _get_expiry(200, twenty_four_hours_seconds)
+            expiry = _get_expiry(200, twenty_four_hours_seconds * 30)
         elif status == -1:
             logger.debug("no response from provider " f"key={key}")
             # Content provider failed to respond; try again in a short interval
-            expiry = _get_expiry(-1, thirty_minutes)
+            expiry = _get_expiry("_1", thirty_minutes)
         else:
             logger.debug("broken link " f"key={key} ")
             expiry = _get_expiry("DEFAULT", twenty_four_hours_seconds * 120)

--- a/api/catalog/api/utils/validate_images.py
+++ b/api/catalog/api/utils/validate_images.py
@@ -88,11 +88,11 @@ def validate_images(query_hash, start_slice, results, image_urls):
         # Cache successful links for a day, and broken links for 120 days.
         if status == 200:
             logger.debug("healthy link " f"key={key} ")
-            expiry = _get_expiry(200, twenty_four_hours_seconds * 30)
+            expiry = _get_expiry(200, twenty_four_hours_seconds)
         elif status == -1:
             logger.debug("no response from provider " f"key={key}")
             # Content provider failed to respond; try again in a short interval
-            expiry = _get_expiry("_1", thirty_minutes)
+            expiry = _get_expiry(-1, thirty_minutes)
         else:
             logger.debug("broken link " f"key={key} ")
             expiry = _get_expiry("DEFAULT", twenty_four_hours_seconds * 120)

--- a/api/catalog/configuration/link_validation_cache.py
+++ b/api/catalog/configuration/link_validation_cache.py
@@ -1,0 +1,67 @@
+import json
+import logging
+import os
+from collections import defaultdict
+from datetime import timedelta
+from typing import Optional
+
+from django.core.exceptions import ImproperlyConfigured
+
+from decouple import config
+
+
+logger = logging.getLogger(__name__)
+
+
+class LinkValidationCacheExpiryConfiguration(defaultdict):
+    """
+    Link validation cache expiry configuration.
+    """
+
+    SETTING_PREFIX = "LINK_VALIDATION_CACHE_EXPIRY__"
+
+    # Cache successful links for a month, and broken links for 120 days.
+    OVERALL_DEFAULT = {"days": 120}
+    STATUS_DEFAULTS = {
+        200: {"days": 30},
+        -1: {"minutes": 30},
+    }
+
+    def __init__(self):
+        default = self._config("default", default=self.OVERALL_DEFAULT)
+        super().__init__(lambda: default)
+
+        self.update(
+            {k: self._config(k, default=v) for k, v in self.STATUS_DEFAULTS.items()}
+        )
+
+        for k, v in os.environ.items():
+            if not k.startswith(self.SETTING_PREFIX) or k.lower().endswith("default"):
+                continue
+
+            try:
+                status = int(k.replace(self.SETTING_PREFIX, ""))
+            except ValueError:
+                raise ImproperlyConfigured(
+                    "Invalid link validation cache setting name: "
+                    f"{self.SETTING_PREFIX}. Please ensure settings "
+                    "are named in the format of "
+                    f"'{self.SETTING_PREFIX}<http integer status code>'."
+                )
+
+            value = self._config(status)
+
+            self.update({status: value})
+
+    def _config(self, key: str | int, default: Optional[dict] = None) -> Optional[int]:
+        try:
+            v = config(
+                f"{self.SETTING_PREFIX}{str(key)}",
+                default=default,
+                cast=lambda x: json.loads(x) if isinstance(x, str) else x,
+            )
+            return int(timedelta(**v).total_seconds())
+        except json.JSONDecodeError:
+            raise ImproperlyConfigured(
+                "Invalid link validation cache setting. " f"Impossible to parse {key}."
+            )

--- a/api/catalog/configuration/link_validation_cache.py
+++ b/api/catalog/configuration/link_validation_cache.py
@@ -51,17 +51,18 @@ class LinkValidationCacheExpiryConfiguration(defaultdict):
 
             value = self._config(status)
 
-            self.update({status: value})
+            self[status] = value
 
     def _config(self, key: str | int, default: Optional[dict] = None) -> Optional[int]:
         try:
             v = config(
                 f"{self.SETTING_PREFIX}{str(key)}",
                 default=default,
+                # Value should either be a str or dict here
                 cast=lambda x: json.loads(x) if isinstance(x, str) else x,
             )
             return int(timedelta(**v).total_seconds())
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, TypeError):
             raise ImproperlyConfigured(
-                "Invalid link validation cache setting. " f"Impossible to parse {key}."
+                f"Invalid link validation cache setting. Impossible to parse {key}."
             )

--- a/api/catalog/settings.py
+++ b/api/catalog/settings.py
@@ -366,4 +366,9 @@ if not DEBUG and SENTRY_DSN:
     # https://sentry.io/share/issue/9af3cdf8ef74420aa7bbb6697760a82c/
     ignore_logger("django.security.DisallowedHost")
 
+# Custom link validation expiration times
+# Overrides can be set via LINK_VALIDATION_CACHE_EXPIRY__<http integer status code>
+# and should be set as kwarg dicts for datetime.timedelta
+# E.g. LINK_VALIDATION_CACHE_EXPIRY__200='{"days": 1}' will set the expiration time
+# for links with HTTP status 200 to 1 day
 LINK_VALIDATION_CACHE_EXPIRY_CONFIGURATION = LinkValidationCacheExpiryConfiguration()

--- a/api/catalog/settings.py
+++ b/api/catalog/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.0/ref/settings/
 """
 
+from datetime import timedelta
 from pathlib import Path
 from socket import gethostbyname, gethostname
 
@@ -20,6 +21,9 @@ from sentry_sdk.integrations.logging import ignore_logger
 
 from catalog.configuration.aws import AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
 from catalog.configuration.elasticsearch import ES, MEDIA_INDEX_MAPPING
+from catalog.configuration.link_validation_cache import (
+    LinkValidationCacheExpiryConfiguration,
+)
 from catalog.configuration.logging import LOGGING
 
 
@@ -361,3 +365,5 @@ if not DEBUG and SENTRY_DSN:
     # from pushing un-actionable alerts to Sentry like
     # https://sentry.io/share/issue/9af3cdf8ef74420aa7bbb6697760a82c/
     ignore_logger("django.security.DisallowedHost")
+
+LINK_VALIDATION_CACHE_EXPIRY_CONFIGURATION = LinkValidationCacheExpiryConfiguration()

--- a/api/test/unit/configuration/link_validation_cache_test.py
+++ b/api/test/unit/configuration/link_validation_cache_test.py
@@ -1,0 +1,76 @@
+from datetime import timedelta
+
+from django.core.exceptions import ImproperlyConfigured
+
+import pytest
+
+from catalog.configuration.link_validation_cache import (
+    LinkValidationCacheExpiryConfiguration,
+)
+
+
+@pytest.mark.parametrize(
+    ("status", "td"),
+    (
+        (200, timedelta(days=30)),
+        (-1, timedelta(minutes=30)),
+        # subsequent entries all use default
+        (400, timedelta(days=120)),
+        (500, timedelta(days=120)),
+        (503, timedelta(days=120)),
+        (401, timedelta(days=120)),
+        (301, timedelta(days=120)),
+    ),
+)
+def test_all_default_values(status, td):
+    config = LinkValidationCacheExpiryConfiguration()
+
+    assert config[status] == int(td.total_seconds())
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expecteds"),
+    (
+        ({"default": '{"days": 1}'}, ((400, timedelta(days=1)),)),
+        ({"200": '{"days": 3}'}, ((200, timedelta(days=3)),)),
+        ({"200": '{"days": 3}'}, ((300, timedelta(days=120)),)),
+        ({"-1": '{"seconds": 120}'}, ((-1, timedelta(seconds=120)),)),
+        # invalid value
+        pytest.param(
+            {"default": "not parseable"},
+            ((400, None),),
+            marks=pytest.mark.raises(exception=ImproperlyConfigured),
+        ),
+        # invalid key
+        pytest.param(
+            {"3a312": '{"hours": 12}'},
+            ((200, None),),
+            marks=pytest.mark.raises(exception=ImproperlyConfigured),
+        ),
+        # multiple configurations
+        (
+            {
+                "default": '{"minutes": 25}',
+                "500": '{"days": 20}',
+                "200": '{"days": 1}',
+            },
+            (
+                (324, timedelta(minutes=25)),
+                (500, timedelta(days=20)),
+                (200, timedelta(days=1)),
+                (400, timedelta(minutes=25)),
+                # -1 still retains it's default value, does not use the ``default`` override
+                (-1, timedelta(minutes=30)),
+            ),
+        ),
+    ),
+)
+def test_environment_overrides(overrides, expecteds, monkeypatch):
+    for k, v in overrides.items():
+        env_key = f"{LinkValidationCacheExpiryConfiguration.SETTING_PREFIX}{k}"
+        monkeypatch.setenv(env_key, v)
+
+    config = LinkValidationCacheExpiryConfiguration()
+
+    for status, td in expecteds:
+        assert config[status] == td.total_seconds()

--- a/api/test/unit/configuration/link_validation_cache_test.py
+++ b/api/test/unit/configuration/link_validation_cache_test.py
@@ -47,6 +47,12 @@ def test_all_default_values(status, td):
             ((200, None),),
             marks=pytest.mark.raises(exception=ImproperlyConfigured),
         ),
+        # invalid arguments for timedelta
+        pytest.param(
+            {"500": '{"not_a_valid_keyword": 12}'},
+            ((200, None),),
+            marks=pytest.mark.raises(exception=ImproperlyConfigured),
+        ),
         # multiple configurations
         (
             {
@@ -59,7 +65,7 @@ def test_all_default_values(status, td):
                 (500, timedelta(days=20)),
                 (200, timedelta(days=1)),
                 (400, timedelta(minutes=25)),
-                # -1 still retains it's default value, does not use the ``default`` override
+                # -1 still retains default value, doesn't use the `default` override
                 (-1, timedelta(minutes=30)),
             ),
         ),


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #878 by @obulat 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
An alternative version of my [other PR to address this issue](https://github.com/WordPress/openverse-api/pull/878) that introduces maximal configurability into the cache times so that we can tweak times for any status code without having to make new releases.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Follow the test instructions in https://github.com/WordPress/openverse-api/pull/878. They are the same here, however in this PR you should also test adding a new environment variable for a status that is not included in the list of default statuses and confirming that it has the expiration used for it.

Also check out the unit tests for the configuration class and confirm they are sufficiently comprehensive.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
