### PR TITLE
Prevent tests from making network requests for link validation and fix potentially non-unique factory props

### DIFF
--- a/api/test/factory/faker.py
+++ b/api/test/factory/faker.py
@@ -1,5 +1,8 @@
+from uuid import uuid4
+
 from factory import Faker
 from faker.providers import BaseProvider
+from faker.providers.internet import Provider as InternetProvider
 from faker.utils.distribution import choices_distribution
 
 
@@ -19,5 +22,11 @@ class WaveformProvider(BaseProvider):
         return WaveformProvider.generate_waveform()
 
 
+class GloballyUniqueUrl(InternetProvider):
+    def globally_unique_url(self) -> str:
+        return f"{self.url()}?{uuid4()}"
+
+
 Faker.add_provider(ChoiceProvider)
 Faker.add_provider(WaveformProvider)
+Faker.add_provider(GloballyUniqueUrl)

--- a/api/test/factory/models/media.py
+++ b/api/test/factory/models/media.py
@@ -20,7 +20,8 @@ class MediaFactory(DjangoModelFactory):
 
     license = Faker("random_element", elements=ALL_LICENSES)
 
-    foreign_landing_url = Faker("url")
+    foreign_landing_url = Faker("globally_unique_url")
+    url = Faker("globally_unique_url")
 
 
 class IdentifierFactory(factory.SubFactory):


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #883 by @sarayourfriend 
Related to #866 by @sarayourfriend

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or  media to show the problem and the solution when appropriate. -->
It turns out the issue with the flaky tests is two fold. We do indeed have the chance for a run to have non-unique urls that clash with database constraints. That is fixed in this PR through adding a new Faker provider `globally_unique_url` that appends a UUID to the URL that Faker uses. Faker's approach does include randomness but it has a small search space, so clashes are easy to come by (especially when generating hundreds of fixtures like we do in some of our tests):

```py
    def url(self, schemes: Optional[List[str]] = None) -> str:
        """
        :param schemes: a list of strings to use as schemes, one will chosen randomly.
            If None, it will generate http and https urls.
            Passing an empty list will result in schemeless url generation like "://domain.com".
        :return: a random url string.

        """
        if schemes is None:
            schemes = ["http", "https"]

        pattern: str = f'{self.random_element(schemes) if schemes else ""}://{self.random_element(self.url_formats)}'

        return self.generator.parse(pattern)
```
 
There is an additional error that the audio fixture has `results_count` at 0 which means the fixture data has all dead links on the first page. As of #855 we no longer back fill dead links if the first page is empty from link validation. That means we need to force the first page to have all valid links, from the perspective of the `validate_images` function. So I'm forcing link statuses into redis before the test and then removing them after the test.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Check the CI test runs and run `just api-test` locally to verify the fix.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [N/A] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
