### PR TITLE
Update CODEOWNERS to use new API team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# All files are owned by the Openverse Maintainers team
-* @WordPress/openverse-maintainers
+# All files are owned by the [Openverse API team](https://github.com/orgs/WordPress/teams/openverse-api)
+* @WordPress/openverse-api


### PR DESCRIPTION
Updates the CODEOWNERS file to use the new [dedicated API Team](https://github.com/orgs/WordPress/teams/openverse-api).