### PR TITLE
Uses a terms array to query data

### DIFF
--- a/api/catalog/api/controllers/search_controller.py
+++ b/api/catalog/api/controllers/search_controller.py
@@ -250,6 +250,7 @@ def _apply_filter(
         method = getattr(s, behaviour)
         return method("bool", should=query)
 
+    return s
 
 def _exclude_filtered(s: Search):
     """

--- a/api/catalog/api/controllers/search_controller.py
+++ b/api/catalog/api/controllers/search_controller.py
@@ -241,15 +241,14 @@ def _apply_filter(
     """
 
     if serializer_field in search_params.data:
-        filters = []
-        for arg in search_params.data[serializer_field].split(","):
-            _param = es_field or serializer_field
-            args = {"name_or_query": "term", _param: arg}
-            filters.append(Q(**args))
+        arguments = search_params.data.get(serializer_field)
+        if arguments is None:
+            return s
+        arguments = arguments.split(",")
+        parameter = es_field or serializer_field
+        query = Q("terms", **{parameter: arguments})
         method = getattr(s, behaviour)
-        return method("bool", should=filters)
-    else:
-        return s
+        return method("bool", should=query)
 
 
 def _exclude_filtered(s: Search):

--- a/api/catalog/api/controllers/search_controller.py
+++ b/api/catalog/api/controllers/search_controller.py
@@ -252,6 +252,7 @@ def _apply_filter(
 
     return s
 
+
 def _exclude_filtered(s: Search):
     """
     Hide data sources from the catalog dynamically.


### PR DESCRIPTION
## Fixes
#698 by @dhruvkb 

## Description
Sends the query arguments as an array. All credit goes to @sarayourfriend  and @obulat for their code on #764 pr. I tested it out on POSTMAN and it works perfectly. 

![image](https://user-images.githubusercontent.com/55840806/187086409-1395bdae-e10a-46b6-8845-42a5fc04ff66.png)

As you can see, the server recieves query parameters as an array

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
