### PR TITLE
Catch struct errors in `watermark/` endpoint

### DIFF
--- a/api/env.docker
+++ b/api/env.docker
@@ -4,6 +4,7 @@ DJANGO_SETTINGS_MODULE=catalog.settings
 DJANGO_SECRET_KEY="ny#b__$$f6ry4wy8oxre97&-68u_0lk3gw(z=d40_dxey3zw0v1"
 DJANGO_DEBUG_ENABLED=True
 
+ENVIRONMENT=development
 ALLOWED_HOSTS=api.openverse.engineering,api-dev.openverse.engineering,host.docker.internal
 
 REDIS_HOST=cache
@@ -18,3 +19,5 @@ UPSTREAM_DATABASE_PORT=5432
 SEMANTIC_VERSION=1.0.0
 
 ELASTICSEARCH_URL=es
+
+WATERMARK_ENABLED=True


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #849 by @sarayourfriend 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR:
- catches struct errors from `piexif.load` function. The last release of this library is from July 2019, so it will need a replacement sooner than later
- sets environment variables to enable the watermark endpoint locally and name the environment properly

I was writing a test but it wasn't failing even before the fix and it's taking too much time to mock. I haven't found a way to reproduce the error locally so hoping just to catch the exception to solve the Sentry alerts.

<details>

<summary>Non failing test</summary>

```python 
# Adding to file: api/test/unit/utils/watermark_test.py

import struct
from io import BytesIO
from PIL import Image
from unittest import mock
from catalog.api.utils.watermark import _open_image

...

def test_catch_struct_errors_from_piexif(requests):
    with mock.patch("PIL.Image.open") as open_mock, mock.patch("piexif.load") as load_mock:
        img_mock = Image.open(BytesIO(_MOCK_IMAGE_BYTES))
        img_mock.info["exif"] = "bad_info"
        open_mock.return_value = img_mock
        load_mock.side_effect = struct.error('unpack requires a buffer of 2 bytes')

        img, exif = _open_image("http://example.com/")

    assert img is not None
    assert exif is None
```

</details>

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Visit the `watermark/` endpoint of any image, eg. http://localhost:50280/v1/images/dba4f725-9370-4442-8db1-522e788d6c55/watermark/

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
