### PR TITLE
Make improvements to the oEmbed endpoint

### DIFF
--- a/api/catalog/api/views/image_views.py
+++ b/api/catalog/api/views/image_views.py
@@ -85,7 +85,7 @@ class ImageViewSet(MediaViewSet):
         try:
             image = self.get_queryset().get(identifier=identifier)
         except Image.DoesNotExist:
-            return get_api_exception("Could not find image.", 404)
+            raise get_api_exception("Could not find image.", 404)
         if not (image.height and image.width):
             image_file = requests.get(image.url, headers=self.OEMBED_HEADERS)
             width, height = PILImage.open(io.BytesIO(image_file.content)).size

--- a/api/catalog/api/views/image_views.py
+++ b/api/catalog/api/views/image_views.py
@@ -81,6 +81,8 @@ class ImageViewSet(MediaViewSet):
         context = self.get_serializer_context()
 
         url = params.validated_data["url"]
+        if url.endswith("/"):
+            url = url[:-1]
         identifier = url.rsplit("/", 1)[1]
         try:
             image = self.get_queryset().get(identifier=identifier)

--- a/api/test/image_integration_test.py
+++ b/api/test/image_integration_test.py
@@ -74,6 +74,32 @@ def test_audio_report(image_fixture):
     report("images", image_fixture)
 
 
+def test_oembed_endpoint_with_non_existent_image():
+    params = {
+        "url": "https://any.domain/any/path/00000000-0000-0000-0000-000000000000",
+    }
+    response = requests.get(
+        f"{API_URL}/v1/images/oembed?{urlencode(params)}", verify=False
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        f"https://any.domain/any/path/{identifier}",  # no trailing slash
+        f"https://any.domain/any/path/{identifier}/",  # trailing slash
+        identifier,  # just identifier instead of URL
+    ],
+)
+def test_oembed_endpoint_with_fuzzy_input(url):
+    params = {"url": url}
+    response = requests.get(
+        f"{API_URL}/v1/images/oembed?{urlencode(params)}", verify=False
+    )
+    assert response.status_code == 200
+
+
 def test_oembed_endpoint_for_json():
     params = {
         "url": f"https://any.domain/any/path/{identifier}",


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #927 by @AetherUnbound 
Addresses #925 by @chrisbartoloburlo

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR fixes the issue of `AssertionError`s being raised instead of a 404 response. The docs for `get_api_exception` say that they are supposed to be used with the `raise` keyword as what it returns are exceptions, not responses.

This PR also handles trailing slashes in URLs. We have been consistently pushes for uniformly using trailing URLs everywhere so our own endpoints should reasonably support them. This is a backwards compatible change.

This PR also adds tests for these changes so that we never regress on them in the future.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
