### PR TITLE
Correct data refresh status message next steps

### DIFF
--- a/ingestion_server/ingestion_server/api.py
+++ b/ingestion_server/ingestion_server/api.py
@@ -269,7 +269,10 @@ class WorkerFinishedResource(BaseTaskResource):
             index_type = target_index.split("-")[0]
             if index_type not in MEDIA_TYPES:
                 index_type = "image"
-            slack.verbose(f"`{index_type}`: Elasticsearch reindex complete")
+            slack.verbose(
+                f"`{index_type}`: Elasticsearch reindex complete | "
+                f"_Next: re-apply indices & constraints_"
+            )
 
             elasticsearch = elasticsearch_connect()
             indexer = TableIndexer(

--- a/ingestion_server/ingestion_server/indexer.py
+++ b/ingestion_server/ingestion_server/indexer.py
@@ -378,7 +378,7 @@ class TableIndexer:
         if alias_stat.exists:
             if not alias_stat.is_alias:
                 # Alias is an index, this is fatal.
-                message = f"There is an index named {alias}, cannot proceed."
+                message = f"There is an index named `{alias}`, cannot proceed."
                 log.error(message)
                 slack.error(message)
                 return
@@ -395,26 +395,23 @@ class TableIndexer:
                     }
                 )
                 message = (
-                    f"`{model_name}`: Migrated alias {alias} "
-                    f"from index `{curr_index}` to index `{dest_index}`."
+                    f"Migrated alias `{alias}` from index "
+                    f"`{curr_index}` to index `{dest_index}`."
                 )
                 log.info(message)
-                slack.info(message)
+                slack.status(model_name, message)
             else:
                 # Alias is already mapped.
                 log.info(
-                    f"`{model_name}`: Alias {alias} already points to "
+                    f"`{model_name}`: Alias `{alias}` already points to "
                     f"index `{dest_index}`."
                 )
         else:
             # Alias does not exist, create it.
             self.es.indices.put_alias(index=dest_index, name=alias)
-            message = (
-                f"`{model_name}`: Created alias `{alias}` pointing to "
-                f"index `{dest_index}`."
-            )
+            message = f"Created alias `{alias}` pointing to index `{dest_index}`."
             log.info(message)
-            slack.info(message)
+            slack.status(model_name, message)
 
         if self.progress is not None:
             self.progress.value = 100  # mark job as completed
@@ -447,7 +444,7 @@ class TableIndexer:
                     if self.is_bad_request is not None:
                         self.is_bad_request.value = 1
                     message = (
-                        f"Alias {target} might be in use so it cannot be deleted. "
+                        f"Alias `{target}` might be in use so it cannot be deleted. "
                         f"Verify that the API does not use this alias and then use the "
                         f"`force_delete` parameter."
                     )
@@ -461,7 +458,7 @@ class TableIndexer:
                     if self.is_bad_request is not None:
                         self.is_bad_request.value = 1
                     message = (
-                        f"Index {target} is associated with aliases "
+                        f"Index `{target}` is associated with aliases "
                         f"{target_stat.alt_names}, cannot delete. Delete aliases first."
                     )
                     log.error(message)
@@ -469,16 +466,16 @@ class TableIndexer:
                     return
 
             self.es.indices.delete(index=target)
-            message = f"Index {target} was deleted."
+            message = f"Index `{target}` was deleted."
             log.info(message)
-            slack.info(message)
+            slack.status(model_name, message)
         else:
             # Cannot delete as target does not exist.
             if self.is_bad_request is not None:
                 self.is_bad_request.value = 1
-            message = f"Target {target} does not exist and cannot be deleted."
+            message = f"Target `{target}` does not exist and cannot be deleted."
             log.info(message)
-            slack.info(message)
+            slack.status(model_name, message)
 
         if self.progress is not None:
             self.progress.value = 100

--- a/ingestion_server/ingestion_server/indexer.py
+++ b/ingestion_server/ingestion_server/indexer.py
@@ -395,18 +395,24 @@ class TableIndexer:
                     }
                 )
                 message = (
-                    f"Migrated alias {alias} "
-                    f"from index {curr_index} to index {dest_index}."
+                    f"`{model_name}`: Migrated alias {alias} "
+                    f"from index `{curr_index}` to index `{dest_index}`."
                 )
                 log.info(message)
                 slack.info(message)
             else:
                 # Alias is already mapped.
-                log.info(f"Alias {alias} already points to index {dest_index}.")
+                log.info(
+                    f"`{model_name}`: Alias {alias} already points to "
+                    f"index `{dest_index}`."
+                )
         else:
             # Alias does not exist, create it.
             self.es.indices.put_alias(index=dest_index, name=alias)
-            message = f"Created alias {alias} pointing to index {dest_index}."
+            message = (
+                f"`{model_name}`: Created alias `{alias}` pointing to "
+                f"index `{dest_index}`."
+            )
             log.info(message)
             slack.info(message)
 

--- a/ingestion_server/ingestion_server/indexer.py
+++ b/ingestion_server/ingestion_server/indexer.py
@@ -395,8 +395,8 @@ class TableIndexer:
                     }
                 )
                 message = (
-                    f"Migrated alias `{alias}` from index "
-                    f"`{curr_index}` to index `{dest_index}`."
+                    f"Migrated alias `{alias}` from index `{curr_index}` to "
+                    f"index `{dest_index}` | _Next: delete old index_"
                 )
                 log.info(message)
                 slack.status(model_name, message)
@@ -466,7 +466,7 @@ class TableIndexer:
                     return
 
             self.es.indices.delete(index=target)
-            message = f"Index `{target}` was deleted."
+            message = f"Index `{target}` was deleted - data refresh complete! :tada:"
             log.info(message)
             slack.status(model_name, message)
         else:

--- a/ingestion_server/ingestion_server/ingest.py
+++ b/ingestion_server/ingestion_server/ingest.py
@@ -319,12 +319,8 @@ def refresh_api_table(
         log.info(f"Running copy-data query: \n{copy_data.as_string(downstream_cur)}")
         downstream_cur.execute(copy_data)
 
-    next_step = (
-        "_Next: {starting data cleaning}_"
-        if table == "image"
-        else "Finished refreshing table"
-    )
-    slack.verbose(f"`{table}`: Data copy complete | {next_step}")
+    next_step = "image data cleaning" if table == "image" else "Elasticsearch reindex"
+    slack.verbose(f"`{table}`: Data copy complete | _Next: {next_step}_")
 
     if table == "image":
         # Step 5: Clean the data
@@ -332,7 +328,7 @@ def refresh_api_table(
         clean_image_data(table)
         log.info("Cleaning completed!")
         slack.verbose(
-            f"`{table}`: Data cleaning complete | " f"Finished refreshing table"
+            f"`{table}`: Data cleaning complete | _Next: Elasticsearch reindex_"
         )
 
     downstream_db.close()
@@ -379,8 +375,7 @@ def promote_api_table(
         log.info("Done remapping constraints! Going live with new table...")
         _update_progress(progress, 99.0)
         slack.verbose(
-            f"`{table}`: Indices & constraints applied, finished refreshing table | "
-            f"_Next: Elasticsearch reindex_"
+            f"`{table}`: Indices & constraints applied | " f"_Next: table promotion_"
         )
 
         # Step 8: Promote the temporary table and delete the original

--- a/ingestion_server/ingestion_server/ingest.py
+++ b/ingestion_server/ingestion_server/ingest.py
@@ -271,7 +271,7 @@ def refresh_api_table(
     """
 
     # Step 1: Get the list of overlapping columns
-    slack.info(f"`{table}`: Starting data refresh | _Next: copying data from upstream_")
+    slack.status(table, "Starting data refresh | _Next: copying data from upstream_")
     downstream_db = database_connect()
     upstream_db = psycopg2.connect(
         dbname=UPSTREAM_DB_NAME,
@@ -320,16 +320,14 @@ def refresh_api_table(
         downstream_cur.execute(copy_data)
 
     next_step = "image data cleaning" if table == "image" else "Elasticsearch reindex"
-    slack.verbose(f"`{table}`: Data copy complete | _Next: {next_step}_")
+    slack.status(table, f"Data copy complete | _Next: {next_step}_")
 
     if table == "image":
         # Step 5: Clean the data
         log.info("Cleaning data...")
         clean_image_data(table)
         log.info("Cleaning completed!")
-        slack.verbose(
-            f"`{table}`: Data cleaning complete | _Next: Elasticsearch reindex_"
-        )
+        slack.status(table, "Data cleaning complete | _Next: Elasticsearch reindex_")
 
     downstream_db.close()
     log.info(f"Finished refreshing table '{table}'.")
@@ -374,16 +372,14 @@ def promote_api_table(
                 downstream_cur.execute(remap_constraint)
         log.info("Done remapping constraints! Going live with new table...")
         _update_progress(progress, 99.0)
-        slack.verbose(
-            f"`{table}`: Indices & constraints applied | " f"_Next: table promotion_"
-        )
+        slack.status(table, "Indices & constraints applied | _Next: table promotion_")
 
         # Step 8: Promote the temporary table and delete the original
         go_live = get_go_live_query(table, index_mapping)
         log.info(f"Running go-live: \n{go_live.as_string(downstream_cur)}")
         downstream_cur.execute(go_live)
-        slack.verbose(
-            f"`{table}`: Finished table promotion | " f"_Next: Elasticsearch promotion_"
+        slack.status(
+            table, "Finished table promotion | _Next: Elasticsearch promotion_"
         )
 
     downstream_db.close()

--- a/ingestion_server/ingestion_server/ingest.py
+++ b/ingestion_server/ingestion_server/ingest.py
@@ -271,7 +271,10 @@ def refresh_api_table(
     """
 
     # Step 1: Get the list of overlapping columns
-    slack.status(table, "Starting data refresh | _Next: copying data from upstream_")
+    slack.status(
+        table,
+        "Starting ingestion server data refresh | _Next: copying data from upstream_",
+    )
     downstream_db = database_connect()
     upstream_db = psycopg2.connect(
         dbname=UPSTREAM_DB_NAME,

--- a/ingestion_server/ingestion_server/slack.py
+++ b/ingestion_server/ingestion_server/slack.py
@@ -68,3 +68,13 @@ def info(text: str, summary: str = None) -> None:
 
 def error(text: str, summary: str = None) -> None:
     _message(text, summary, level=Level.ERROR)
+
+
+def status(model: str, text: str) -> None:
+    """
+    Send a message regarding the status of the data refresh.
+
+    Model is required an all messages get prepended with the model.
+    """
+    text = f"`{model}`: {text}"
+    info(text, None)

--- a/justfile
+++ b/justfile
@@ -179,6 +179,10 @@ _ing-api data port="50281":
 @promote model="image" suffix="init" alias="image":
     just _ing-api '{"model": "{{ model }}", "action": "PROMOTE", "index_suffix": "{{ suffix }}", "alias": "{{ alias }}"}'
 
+# Delete an index in Elasticsearch
+@delete suffix model="image" alias="image":
+    just _ing-api '{"model": "{{ model }}", "action": "DELETE_INDEX", "index_suffix": "{{ suffix }}"}'
+
 # Run ingestion-server tests locally
 ing-testlocal *args:
     cd ingestion_server && pipenv run ./test/run_test.sh {{ args }}

--- a/justfile
+++ b/justfile
@@ -180,7 +180,7 @@ _ing-api data port="50281":
     just _ing-api '{"model": "{{ model }}", "action": "PROMOTE", "index_suffix": "{{ suffix }}", "alias": "{{ alias }}"}'
 
 # Delete an index in Elasticsearch
-@delete suffix model="image" alias="image":
+@delete model="image" suffix="init" alias="image":
     just _ing-api '{"model": "{{ model }}", "action": "DELETE_INDEX", "index_suffix": "{{ suffix }}"}'
 
 # Run ingestion-server tests locally


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #887 by @AetherUnbound

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR builds off of the changes in #707 and corrects some of the messaging around next steps within the data refresh update steps.

I've also added a new `slack::status` method which will prepend the model name to the beginning of the slack message, which should hopefully make it easier to be more consistent around the messaging. Admittedly "status" is a pretty generic name, if folks think `data_refresh_status` or something else would be better, happy to rename it! 

I've added a just recipe for the index deletion step too, which is in-line with the other recipes we have around indexing.

![image](https://user-images.githubusercontent.com/10214785/192402058-52afbe07-4d6d-4626-bd73-5d0f6fcf38d8.png)


## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
The best way to run this would be to add a `SLACK_WEBHOOK` URL to the `ingestion_server/env.docker` file, then run the following:

1. `just recreate` - this will run the audio and image data refreshes, and display messages associated with creating index aliases towards the end.
1. `just ingest-upstream image new-test` - this will start the process for creating a new index called `new-test`
1. `just promote image new-test` - run this once the previous step gets to "Indices & constraints applied | _Next: table promotion_" step
1. `just delete image` - run this once the previous step gets to "Migrated alias image from index image-init to index image-new-test"

This will emulate the entire process of a data refresh, and you should see all the messages we're likely to see during a normal data refresh process!

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
