### PR TITLE
Do not unfurl links or media in Slack notifications

### DIFF
--- a/ingestion_server/ingestion_server/slack.py
+++ b/ingestion_server/ingestion_server/slack.py
@@ -50,6 +50,8 @@ def _message(text: str, summary: str = None, level: Level = Level.INFO) -> None:
         "text": summary,
         "username": f"Data Refresh Notification | {environment.upper()}",
         "icon_emoji": "arrows_counterclockwise",
+        "unfurl_links": False,
+        "unfurl_media": False,
     }
     try:
         requests.post(webhook, json=data)


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #954 by @stacimc

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Prevents links and media from unfurling in Slack notifications in the ingestion server.

I've hard-coded this for all Slack notifications rather than exposing this as an option, as is done in the Catalog. For the time  being I don't see any scenarios where we would _want_ to unfurl for the ingestion server, so I do not think it is worth the effort to implement and test. If a situation arises, it should be a quick addition.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
This change is pretty straightforward and a nearly identical change has been tested in the Catalog. However, I did test this locally by simulating a recent production error that displayed an image. This error happens during reindexing when duplicate keys are found. To reproduce it I did the following:

1. Updated the [sample_date/sample_images.csv](https://github.com/WordPress/openverse-api/blob/main/sample_data/sample_images.csv) to include a duplicate. To do this, I picked two arbitrary rows and replaced the `url` column on one row with _the url of another row, minus the protocol._ The exact diff I used is available in [this patch.](https://gist.github.com/stacimc/770f347ae3f39abc4d1072068842c252)
2. Set the SLACK_WEBHOOK and LOG_LEVEL environment variables.
3. Run `just recreate` in the `openverse-api` root directory. This will attempt to reindex ES and it should encounter the duplicate key error and notify Slack.

Here's a comparison of an old Slack notification from production, next to the notification from my local test:
| Production | Local test |
| --- | --- |
| <img width="661" alt="Screen Shot 2022-09-27 at 4 20 19 PM" src="https://user-images.githubusercontent.com/63313398/192655794-a36ba5dd-24e9-4aec-90da-0143fcf22ea6.png"> | <img width="622" alt="Screen Shot 2022-09-27 at 4 20 32 PM" src="https://user-images.githubusercontent.com/63313398/192655807-d9df0ca9-b223-4e8b-94ad-4d7d924ec22b.png"> |



## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
