### PR TITLE
Add a recipe `ps` that runs after `up`

### DIFF
--- a/justfile
+++ b/justfile
@@ -44,7 +44,7 @@ build *args:
     just dc build {{ args }}
 
 # Bring all Docker services up
-up flags="": && ps
+up flags="":
     just dc up -d {{ flags }}
 
 # Take all Docker services down

--- a/justfile
+++ b/justfile
@@ -44,12 +44,16 @@ build *args:
     just dc build {{ args }}
 
 # Bring all Docker services up
-up flags="":
+up flags="": && ps
     just dc up -d {{ flags }}
 
 # Take all Docker services down
 down flags="":
     just dc down {{ flags }}
+
+# List all running services and their URLs and ports
+@ps:
+    python3 scripts/ps.py
 
 # Recreate all volumes and containers from scratch
 recreate:

--- a/scripts/ps.py
+++ b/scripts/ps.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+from dataclasses import dataclass
+
+
+@dataclass
+class Service:
+    name: str
+    bindings: list[tuple[str, int, int]]
+
+    def print(self):
+        """
+        Print the formatted output for the service. The output contains the following:
+        - name (in bold)
+        - each URL (with the correct protocol) and the container port to which it maps
+
+        It specially handles the singular NGINX port 9443 which serves over ``https``.
+        """
+
+        print(f"\033[1m{self.name}:\033[0m")
+        for url, host_port, container_port in self.bindings:
+            proto = "http"
+            if self.name == "proxy" and container_port == 9443:
+                proto = "https"
+            print(f"- {proto}://{url}:{host_port} (→ {container_port})")
+
+
+def get_ps() -> str:
+    """
+    Invoke Docker Compose to get the current status of all services. This function uses
+    the ``format`` flag to get the output as JSON which can be parsed and wrangled.
+
+    :return: the output printed by the subprocess to STDOUT
+    """
+
+    proc = subprocess.run(
+        ["just", "dc", "ps", "--format=json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return proc.stdout
+
+
+def parse_ps() -> list[Service]:
+    """
+    Convert the JSON output given by Docker Compose into a list of services and their
+    port mappings.
+
+    :return: a list of running services with their port
+    """
+
+    services: list[Service] = []
+
+    data = json.loads(get_ps())
+    for service in data:
+        name = service["Service"]
+
+        bindings = []
+        publishers = service["Publishers"]
+        for publisher in publishers:
+            url = publisher["URL"]
+            container_port = publisher["TargetPort"]
+            host_port = publisher["PublishedPort"]
+            if host_port:
+                bindings.append((url, host_port, container_port))
+        if bindings:
+            services.append(Service(name, bindings))
+
+    return services
+
+
+def print_ps():
+    """Print the formatted output for each service."""
+
+    for service in parse_ps():
+        service.print()
+
+
+if __name__ == "__main__":
+    print_ps()

--- a/scripts/ps.py
+++ b/scripts/ps.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import json
 import subprocess
 from dataclasses import dataclass
+from typing import List, Tuple
 
 
 @dataclass
 class Service:
     name: str
-    bindings: list[tuple[str, int, int]]
+    bindings: List[Tuple[str, int, int]]
 
     def print(self):
         """
@@ -43,7 +46,7 @@ def get_ps() -> str:
     return proc.stdout
 
 
-def parse_ps() -> list[Service]:
+def parse_ps() -> List[Service]:
     """
     Convert the JSON output given by Docker Compose into a list of services and their
     port mappings.
@@ -51,7 +54,7 @@ def parse_ps() -> list[Service]:
     :return: a list of running services with their port
     """
 
-    services: list[Service] = []
+    services: List[Service] = []
 
     data = json.loads(get_ps())
     for service in data:


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #952 by @zackkrida 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR adds a recipe `ps` that invokes a Python script to parse the output of `docker-compose ps` and generate a list of URLs for each running service.

It currently does not see to verify if something is indeed running at that URLs (notably API port 50230, which is usually bound but rarely used).

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
0. Checkout this PR and run `just up`.
1. See the list of services being printed automatically after `up` is complete.
2. Run `just ps`.
3. See the list of services.

## Screenshots

<img width="1082" alt="Screenshot 2022-09-28 at 5 41 56 AM" src="https://user-images.githubusercontent.com/16580576/192668154-08c2c07c-3137-4a6f-ad76-d2eac4055448.png">

In iTerm2, these URLs are clickable with <kbd>Cmd</kbd> held down, super helpful!

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
