### PR TITLE
Fix URL in API consumer docs

### DIFF
--- a/api/catalog/api/docs/README.md
+++ b/api/catalog/api/docs/README.md
@@ -23,7 +23,7 @@ instructions on obtaining an API key.
 
 ## Register for a key
 Before using the Openverse API, you need to register access via OAuth2. This can
-be done using the `/v1/auth_tokens/register` endpoint.
+be done using the `/v1/auth_tokens/register/` endpoint.
 
 Example on how to register for a key:
 ```bash
@@ -31,7 +31,7 @@ $ curl \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"name": "My amazing project", "description": "To access Openverse API", "email": "user@example.com"}' \
-  "https://api.openverse.engineering/v1/auth_tokens/register"
+  "https://api.openverse.engineering/v1/auth_tokens/register/"
 ```
 If your request is successful, you will get a `client_id` and `client_secret`.
 

--- a/api/catalog/api/models/models.py
+++ b/api/catalog/api/models/models.py
@@ -12,7 +12,7 @@ class ContentProvider(models.Model):
 
     For example,
     - Wikimedia for audio can have
-        ``provider_identifier`` as  wikimedia_audio" and
+        ``provider_identifier`` as  "wikimedia_audio" and
         ``provider_name`` as "Wikimedia"
     - Wikimedia for images can have
         ``provider_identifier`` as "wikimedia_images" or "wikimedia" and

--- a/api/catalog/urls/__init__.py
+++ b/api/catalog/urls/__init__.py
@@ -2,6 +2,7 @@
 
 The `urlpatterns` list routes URLs to views. For more information please see:
     https://docs.djangoproject.com/en/2.0/topics/http/urls/
+
 Examples:
 Function views
     1. Add an import:  from my_app import views


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Prevents confusing errors like [this reported in the Fixing WordPress Forums](https://wordpress.org/support/topic/openverse-register-error/). The user was trying to register for a key following instructions but the API returned the following:

```json
{
	"detail": "Method \"GET\" not allowed."
}
```

I tried to reproduce it and found this happens when missing the trailing slash in the endpoint.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR fixes the docs URLs to prevent this from happening. Also includes some other minor docs changes to remove warnings when building sphinx docs (`just sphinx-make`).

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
`just up` and check http://localhost:50280/v1/#section/Register-and-Authenticate

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
