### PR TITLE
Make quoted queries behave as described in the API documentation (return exact matches only)

### DIFF
--- a/api/catalog/api/controllers/search_controller.py
+++ b/api/catalog/api/controllers/search_controller.py
@@ -357,7 +357,7 @@ def search(
         quotes_stripped = query.replace('"', "")
         exact_match_boost = Q(
             "simple_query_string",
-            fields=["title.exact"],
+            fields=["title"],
             query=f"{quotes_stripped}",
             boost=10000,
         )

--- a/api/catalog/api/controllers/search_controller.py
+++ b/api/catalog/api/controllers/search_controller.py
@@ -340,18 +340,25 @@ def search(
     search_fields = ["tags.name", "title", "description"]
     if "q" in search_params.data:
         query = _quote_escape(search_params.data["q"])
+        base_query_kwargs = {
+            "query": query,
+            "fields": search_fields,
+            "default_operator": "AND",
+        }
+
+        if '"' in query:
+            base_query_kwargs["quote_field_suffix"] = ".exact"
+
         s = s.query(
             "simple_query_string",
-            query=query,
-            fields=search_fields,
-            default_operator="AND",
+            **base_query_kwargs,
         )
-        # Boost exact matches
+        # Boost exact matches on the title
         quotes_stripped = query.replace('"', "")
         exact_match_boost = Q(
             "simple_query_string",
-            fields=["title"],
-            query=f'"{quotes_stripped}"',
+            fields=["title.exact"],
+            query=f"{quotes_stripped}",
             boost=10000,
         )
         s = search_client.query(Q("bool", must=s.query, should=exact_match_boost))

--- a/api/catalog/api/examples/audio_requests.py
+++ b/api/catalog/api/examples/audio_requests.py
@@ -10,7 +10,7 @@ identifier = "8624ba61-57f1-4f98-8a85-ece206c319cf"
 syntax_examples = {
     "using single query parameter": "test",
     "using multiple query parameters": "test&license=pdm,by&categories=illustration&page_size=1&page=1",  # noqa: E501
-    "that is an exact match of Giacomo Puccini": '"Giacomo Puccini"',
+    "that is an exact match of Giacomo Puccini": r"%22Giacomo%20Puccini%22",
     "related to both dog and cat": "dog+cat",
     "related to dog or cat, but not necessarily both": "dog|cat",
     "related to dog but won't include results related to 'pug'": "dog -pug",

--- a/api/catalog/api/examples/image_requests.py
+++ b/api/catalog/api/examples/image_requests.py
@@ -10,7 +10,7 @@ identifier = "4bc43a04-ef46-4544-a0c1-63c63f56e276"
 syntax_examples = {
     "using single query parameter": "test",
     "using multiple query parameters": "test&license=pdm,by&categories=illustration&page_size=1&page=1",  # noqa: E501
-    "that are an exact match of Claude Monet": '"Claude Monet"',
+    "that are an exact match of Claude Monet": "%22Claude%20Monet%22",
     "related to both dog and cat": "dog+cat",
     "related to dog or cat, but not necessarily both": "dog|cat",
     "related to dog but won't include results related to 'pug'": "dog -pug",

--- a/api/test/audio_integration_test.py
+++ b/api/test/audio_integration_test.py
@@ -15,6 +15,7 @@ from test.media_integration import (
     search_by_category,
     search_consistency,
     search_quotes,
+    search_quotes_exact,
     search_source_and_excluded,
     search_special_chars,
     stats,
@@ -99,6 +100,11 @@ def test_search_source_and_excluded():
 
 def test_search_quotes():
     search_quotes("audio", "love")
+
+
+def test_search_quotes_exact():
+    # ``water running`` returns different results when quoted vs unquoted
+    search_quotes_exact("audio", "water running")
 
 
 def test_search_with_special_characters():

--- a/api/test/image_integration_test.py
+++ b/api/test/image_integration_test.py
@@ -15,6 +15,7 @@ from test.media_integration import (
     search_all_excluded,
     search_consistency,
     search_quotes,
+    search_quotes_exact,
     search_source_and_excluded,
     search_special_chars,
     stats,
@@ -51,6 +52,11 @@ def test_search_source_and_excluded():
 
 def test_search_quotes():
     search_quotes("images", "dog")
+
+
+def test_search_quotes_exact():
+    # ``bird perched`` returns different results when quoted vs unquoted
+    search_quotes_exact("images", "bird perched")
 
 
 def test_search_with_special_characters():

--- a/api/test/media_integration.py
+++ b/api/test/media_integration.py
@@ -45,6 +45,25 @@ def search_quotes(media_path, q="test"):
     assert response.status_code == 200
 
 
+def search_quotes_exact(media_path, q):
+    """Only returns exact matches for the given query"""
+    unquoted_response = requests.get(f"{API_URL}/v1/{media_path}?q={q}", verify=False)
+    assert unquoted_response.status_code == 200
+    unquoted_results = unquoted_response.json()["results"]
+    assert len(unquoted_results) > 0
+
+    quoted_response = requests.get(f'{API_URL}/v1/{media_path}?q="{q}"', verify=False)
+    assert quoted_response.status_code == 200
+    quoted_results = quoted_response.json()["results"]
+    assert len(quoted_results) > 0
+
+    # The rationale here is that the unquoted results will match more records due
+    # to the query being overall less strict. Quoting the query will make it more
+    # strict causing it to return fewer results.
+    # Above we check that the results are not 0 to confirm that we do still get results back.
+    assert len(quoted_results) < len(unquoted_results)
+
+
 def search_special_chars(media_path, q="test"):
     """Returns a response when query includes special characters."""
     response = requests.get(f"{API_URL}/v1/{media_path}?q={q}!", verify=False)

--- a/api/test/media_integration.py
+++ b/api/test/media_integration.py
@@ -49,19 +49,19 @@ def search_quotes_exact(media_path, q):
     """Only returns exact matches for the given query"""
     unquoted_response = requests.get(f"{API_URL}/v1/{media_path}?q={q}", verify=False)
     assert unquoted_response.status_code == 200
-    unquoted_results = unquoted_response.json()["results"]
-    assert len(unquoted_results) > 0
+    unquoted_result_count = unquoted_response.json()["result_count"]
+    assert unquoted_result_count > 0
 
     quoted_response = requests.get(f'{API_URL}/v1/{media_path}?q="{q}"', verify=False)
     assert quoted_response.status_code == 200
-    quoted_results = quoted_response.json()["results"]
-    assert len(quoted_results) > 0
+    quoted_result_count = quoted_response.json()["result_count"]
+    assert quoted_result_count > 0
 
     # The rationale here is that the unquoted results will match more records due
     # to the query being overall less strict. Quoting the query will make it more
     # strict causing it to return fewer results.
     # Above we check that the results are not 0 to confirm that we do still get results back.
-    assert len(quoted_results) < len(unquoted_results)
+    assert quoted_result_count < unquoted_result_count
 
 
 def search_special_chars(media_path, q="test"):


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Fixes #933 by @AetherUnbound 

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Conditionally applies the `quote_field_suffix` query feature as suggested in the Elasticsearch documentation that @AetherUnbound shared in the linked issue: https://www.elastic.co/guide/en/elasticsearch/reference/current/mixing-exact-search-with-stemming.html

We can continue to "boost" exact matches against the title as we originally were, but I've added the `.exact` modifier there as well to ensure that the boost only applies to actual exact matches.

The latter is hard to test locally, I haven't found any suitable queries for it in the test data and I do not know how to efficiently add usable test data.

The former, however, is pretty straightforward to test locally. Find a query that returns some results that you could narrow using an exact match. I found one for images and one for audio that are used in the integration tests:

Audio: `http://localhost:50280/v1/audio/?q=water%20running` vs `http://localhost:50280/v1/audio/?q=%22water%20running%22`

Images: `http://localhost:50280/v1/images/?q=bird%20perched` vs `http://localhost:50280/v1/images/?q=%22bird%20perched%22`

You can try these locally to see how the results differ and that the way they differ makes sense. The integration test only confirms that they do indeed differ. I'm not  sure how to reasonably test that the exact match is "working" in a way that doesn't test implementation details. We could intercept the query to ES and see that `quote_field_suffix` is applied. Alternatively we could test that the exact match is present in the match fields of the response... but both feel like either testing Elasticsearch (which we do not have to do) or testing an abstract implementation detail that doesn't approximate the actual expectation. Any advice here or creative solutions would be appreciated.

Finally, I also fixed the incorrectly quoted example queries for images and audio exact match queries.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Check out the testing instructions in the previous section. If you can find any other queries that demonstrate this working with the test data, please share them here.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
