### PR TITLE
Add db connection commands and non-root user for `web` container

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -83,7 +83,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: extractions/setup-just@v1
+
+      - name: Setup just
+        uses: extractions/setup-just@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all images
         uses: actions/download-artifact@v2
@@ -134,6 +138,8 @@ jobs:
 
       - name: Setup just
         uses: extractions/setup-just@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Python
         uses: actions/setup-python@v2
@@ -188,6 +194,8 @@ jobs:
 
       - name: Setup just
         uses: extractions/setup-just@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all images
         uses: actions/download-artifact@v2
@@ -229,6 +237,8 @@ jobs:
 
       - name: Setup just
         uses: extractions/setup-just@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all images
         uses: actions/download-artifact@v2
@@ -250,7 +260,11 @@ jobs:
       - build-images
     steps:
       - uses: actions/checkout@v3
-      - uses: extractions/setup-just@v1
+
+      - name: Setup just
+        uses: extractions/setup-just@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all images
         uses: actions/download-artifact@v2
@@ -283,6 +297,8 @@ jobs:
 
       - name: Setup just
         uses: extractions/setup-just@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all images
         uses: actions/download-artifact@v2
@@ -308,6 +324,8 @@ jobs:
 
       - name: Setup just
         uses: extractions/setup-just@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all images
         uses: actions/download-artifact@v2
@@ -378,6 +396,8 @@ jobs:
 
       - name: Setup just
         uses: extractions/setup-just@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all images
         uses: actions/download-artifact@v2

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -90,7 +90,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all images
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: /tmp
 
@@ -161,7 +161,7 @@ jobs:
           just _ing-install
 
       - name: Download image `ingestion_server`
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ingestion_server
           path: /tmp
@@ -198,7 +198,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all images
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: /tmp
 
@@ -241,7 +241,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all images
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: /tmp
 
@@ -267,7 +267,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all images
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: /tmp
 
@@ -301,7 +301,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all images
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: /tmp
 
@@ -328,7 +328,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all images
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: /tmp
 
@@ -366,7 +366,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download image `${{ matrix.image }}`
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.image }}
           path: /tmp
@@ -400,7 +400,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all images
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: /tmp
 
@@ -471,9 +471,11 @@ jobs:
 
       - name: Setup just
         uses: extractions/setup-just@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all images
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: /tmp
 

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -96,7 +96,9 @@ jobs:
           docker load --input /tmp/ingestion_server/ingestion_server.tar
 
       - name: collectstatic
-        run: just collectstatic
+        run: just collectstatic-as-admin
+        env:
+          STATIC_ROOT: ./static
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -278,6 +278,8 @@ jobs:
 
       - name: Run check
         run: just dj validateopenapischema
+        env:
+          DC_USER: root
 
       - name: Upload schema on failure
         if: failure()
@@ -441,7 +443,6 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login == 'WordPress' && github.actor != 'dependabot[bot]'
     needs:
       - build-images
-
     steps:
       - uses: peter-evans/find-comment@v2
         id: preview-comment
@@ -489,6 +490,8 @@ jobs:
           just sphinx-make
           sudo chown "$USER:$USER" -R ./api
           mv ./api/build/html /tmp/preview
+        env:
+          DC_USER: root
 
       # Otherwise we end up with any extra stuff not git-ignored in the gh-pages branch
       - name: Recreate working directory to avoid superfluous files

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -100,9 +100,10 @@ jobs:
           docker load --input /tmp/ingestion_server/ingestion_server.tar
 
       - name: collectstatic
-        run: just collectstatic-as-admin
+        run: just collectstatic
         env:
           STATIC_ROOT: ./static
+          DC_USER: root
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -59,7 +59,7 @@ jobs:
           install: true
 
       - name: Build image `${{ matrix.image }}`
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ${{ matrix.image }}
           push: false
@@ -111,7 +111,7 @@ jobs:
           install: true
 
       - name: Build image `nginx`
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: api
           target: nginx

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -79,7 +79,7 @@ COPY --from=awf /usr/local/bin/audiowaveform /usr/local/bin
 #   - libpq-dev: required by `psycopg2`
 # - Create directory for dumping API logs
 RUN apt-get update \
-      && apt-get install -y curl libpq-dev libexempi8 \
+      && apt-get install -y curl libpq-dev libexempi8 postgresql-client \
       && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /var/log/openverse_api/openverse_api.log
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -45,12 +45,8 @@ FROM nginx:1.23.2-alpine as nginx
 
 WORKDIR /app
 
-# Create a non-root user
-RUN useradd --create-home opener
-USER opener
-
-COPY --chown=opener nginx.conf.template /etc/nginx/templates/openverse-api.conf.template
-COPY --chown=opener /static /app/static
+COPY nginx.conf.template /etc/nginx/templates/openverse-api.conf.template
+COPY /static /app/static
 
 # Only environment variables with this prefix will be available in the template
 ENV NGINX_ENVSUBST_FILTER="DJANGO_NGINX_"

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -45,8 +45,12 @@ FROM nginx:1.23.2-alpine as nginx
 
 WORKDIR /app
 
-COPY nginx.conf.template /etc/nginx/templates/openverse-api.conf.template
-COPY /static /app/static
+# Create a non-root user
+RUN useradd --create-home opener
+USER opener
+
+COPY --chown=opener nginx.conf.template /etc/nginx/templates/openverse-api.conf.template
+COPY --chown=opener /static /app/static
 
 # Only environment variables with this prefix will be available in the template
 ENV NGINX_ENVSUBST_FILTER="DJANGO_NGINX_"

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -83,8 +83,12 @@ RUN apt-get update \
       && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /var/log/openverse_api/openverse_api.log
 
+# Create a non-root user
+RUN useradd --create-home opener
+USER opener
+
 # Copy code into the final image
-COPY . /api/
+COPY --chown=opener . /api/
 
 # Exposes
 # - 8000: Dev server for API Django app

--- a/api/Pipfile
+++ b/api/Pipfile
@@ -18,6 +18,7 @@ remote-pdb = "~=2.1"
 sphinx = "~=5.2"
 sphinx-autobuild = "~=2021.3"
 pook = "~=1.0"
+pgcli = "~=3.5"
 
 [packages]
 aws-requests-auth = "~=0.4"

--- a/api/Pipfile.lock
+++ b/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9777026074f3fe739971d6d1fd6f21932f03657e5aaa4db5ffb574004d196acc"
+            "sha256": "171204ed1f04c6ab54b31d2dc8b51c27e81d402e3fd2affb018226fc1d64329a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -151,19 +151,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:4cef9ebc9c15fd0abd5097d6fa2676a8785c7b80d3e9242a783480b6192df2ea",
-                "sha256:5a37503ad456a6beae2740d2367c0a514b07ef0e134cdcc2b77cc8481832751b"
+                "sha256:672b97a634f3408d455bf94a6dfd59ef0c6150019885bc7107e465f062d58c26",
+                "sha256:e0d6215313b03f09a9a38eccc88c1d3ba9868bcaaeb8b20eeb6d88fc3018b94d"
             ],
             "index": "pypi",
-            "version": "==1.26.31"
+            "version": "==1.26.32"
         },
         "botocore": {
             "hashes": [
-                "sha256:2e3cacf13d0997fd931e3a3f7d819bf200df8dcc74609a027ebc9dff2c0980d7",
-                "sha256:2ef360b7323f94128943a40297e457832384141577ded0b807e6d6a794fba636"
+                "sha256:27bc3903f7f8c813efd1605ff13ffdfca2c37dc78cadfa488cfda78fca323deb",
+                "sha256:b1a65edca151665a6844bf9f317440e31d8d5e4cbce3477f2661462e20c213b1"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.29.31"
+            "version": "==1.29.32"
         },
         "certifi": {
             "hashes": [
@@ -1040,10 +1040,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:222439474e9c98fced559f1709d89e6c9cbf8d79c794ff3eb9f8800064291427",
-                "sha256:e89512406b793ca39f5971bc999cc538ce125c0e51c27941bef4568b460095e2"
+                "sha256:7ccfae7b4b2c067464a6733c6261673fdb8fd1be905460396b97a073e9fa683a",
+                "sha256:93007def75ae22f7cd991c84e02d434876818661f8df9ad5df9e950ff4e52cfd"
             ],
-            "version": "==2022.6"
+            "version": "==2022.7"
         },
         "redis": {
             "hashes": [
@@ -1134,11 +1134,11 @@
         },
         "sentry-sdk": {
             "hashes": [
-                "sha256:3c9bc64025976842c1103cd75d45cff94a7c0cc48fa07770d07a09d2ab8dac30",
-                "sha256:dc0fe6ef2f77a3853b399c75c97d87be7666098817c1c314f8fcdf68a6865914"
+                "sha256:5bbe4b72de22f9ac1e67f2a4e6efe8fbd595bb59b7b223443f50fe5802a5551c",
+                "sha256:9f0b960694e2d8bb04db4ba6ac2a645040caef4e762c65937998ff06064f10d6"
             ],
             "index": "pypi",
-            "version": "==1.12.0"
+            "version": "==1.12.1"
         },
         "setuptools": {
             "hashes": [
@@ -1489,6 +1489,25 @@
             "markers": "python_full_version >= '3.6.0'",
             "version": "==2.1.1"
         },
+        "cli-helpers": {
+            "extras": [
+                "styles"
+            ],
+            "hashes": [
+                "sha256:2e93cda413052f38042d47b804eea049a4f7860ac9826f3763719288d77435ea",
+                "sha256:e7174d003a2b58fd3e31a73fbbc45d5aa513de62cbd42d437f78b9658bd5f967"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.3.0"
+        },
+        "click": {
+            "hashes": [
+                "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e",
+                "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.3"
+        },
         "colorama": {
             "hashes": [
                 "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
@@ -1496,6 +1515,12 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
             "version": "==0.4.6"
+        },
+        "configobj": {
+            "hashes": [
+                "sha256:a2f5650770e1c87fb335af19a9b7eb73fc05ccf22144eb68db7d00cd2bcb0902"
+            ],
+            "version": "==5.0.6"
         },
         "decorator": {
             "hashes": [
@@ -1802,6 +1827,33 @@
             "markers": "python_full_version >= '3.7.0' and python_full_version < '4.0.0'",
             "version": "==0.4.3"
         },
+        "pendulum": {
+            "hashes": [
+                "sha256:0731f0c661a3cb779d398803655494893c9f581f6488048b3fb629c2342b5394",
+                "sha256:1245cd0075a3c6d889f581f6325dd8404aca5884dea7223a5566c38aab94642b",
+                "sha256:29c40a6f2942376185728c9a0347d7c0f07905638c83007e1d262781f1e6953a",
+                "sha256:2d1619a721df661e506eff8db8614016f0720ac171fe80dda1333ee44e684087",
+                "sha256:318f72f62e8e23cd6660dbafe1e346950281a9aed144b5c596b2ddabc1d19739",
+                "sha256:33fb61601083f3eb1d15edeb45274f73c63b3c44a8524703dc143f4212bf3269",
+                "sha256:3481fad1dc3f6f6738bd575a951d3c15d4b4ce7c82dce37cf8ac1483fde6e8b0",
+                "sha256:4c9c689747f39d0d02a9f94fcee737b34a5773803a64a5fdb046ee9cac7442c5",
+                "sha256:7c5ec650cb4bec4c63a89a0242cc8c3cebcec92fcfe937c417ba18277d8560be",
+                "sha256:94b1fc947bfe38579b28e1cccb36f7e28a15e841f30384b5ad6c5e31055c85d7",
+                "sha256:9702069c694306297ed362ce7e3c1ef8404ac8ede39f9b28b7c1a7ad8c3959e3",
+                "sha256:b06a0ca1bfe41c990bbf0c029f0b6501a7f2ec4e38bfec730712015e8860f207",
+                "sha256:b6c352f4bd32dff1ea7066bd31ad0f71f8d8100b9ff709fb343f3b86cee43efe",
+                "sha256:c501749fdd3d6f9e726086bf0cd4437281ed47e7bca132ddb522f86a1645d360",
+                "sha256:c807a578a532eeb226150d5006f156632df2cc8c5693d778324b43ff8c515dd0",
+                "sha256:db0a40d8bcd27b4fb46676e8eb3c732c67a5a5e6bfab8927028224fbced0b40b",
+                "sha256:de42ea3e2943171a9e95141f2eecf972480636e8e484ccffaf1e833929e9e052",
+                "sha256:e95d329384717c7bf627bf27e204bc3b15c8238fa8d9d9781d93712776c14002",
+                "sha256:f5e236e7730cab1644e1b87aca3d2ff3e375a608542e90fe25685dae46310116",
+                "sha256:f888f2d2909a414680a29ae74d0592758f2b9fcdee3549887779cd4055e975db",
+                "sha256:fb53ffa0085002ddd43b6ca61a7b34f2d4d7c3ed66f931fe599e1a531b42af9b"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.1.2"
+        },
         "pexpect": {
             "hashes": [
                 "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937",
@@ -1809,6 +1861,21 @@
             ],
             "markers": "sys_platform != 'win32'",
             "version": "==4.8.0"
+        },
+        "pgcli": {
+            "hashes": [
+                "sha256:0bcef2c628bae8443822f647e1b67680f219798625adf7ffa0920049056088a1",
+                "sha256:cc448d95159fc0903d36182992778a096eda5752d660d47671383c8e2bf633f1"
+            ],
+            "index": "pypi",
+            "version": "==3.5.0"
+        },
+        "pgspecial": {
+            "hashes": [
+                "sha256:64443bbc9ad09b57d0f4dcbb38eff44d52853b7418c9ea52f5857abe1bb534ec",
+                "sha256:fbdfbb355e99e0514870e32cb0bfd2a01848364511037ab92040635f29417a50"
+            ],
+            "version": "==2.0.1"
         },
         "pickleshare": {
             "hashes": [
@@ -1841,6 +1908,14 @@
             ],
             "markers": "python_full_version >= '3.6.2'",
             "version": "==3.0.36"
+        },
+        "psycopg": {
+            "hashes": [
+                "sha256:812100b4215747f18d0c0f14cb568c3f39d9676053fd3e326bd0c718cfc37f33",
+                "sha256:aff1561afa079992f653e5bc34ff3d5b29023e26f9e691db6ac953033f390890"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.1.6"
         },
         "ptyprocess": {
             "hashes": [
@@ -1934,10 +2009,18 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:222439474e9c98fced559f1709d89e6c9cbf8d79c794ff3eb9f8800064291427",
-                "sha256:e89512406b793ca39f5971bc999cc538ce125c0e51c27941bef4568b460095e2"
+                "sha256:7ccfae7b4b2c067464a6733c6261673fdb8fd1be905460396b97a073e9fa683a",
+                "sha256:93007def75ae22f7cd991c84e02d434876818661f8df9ad5df9e950ff4e52cfd"
             ],
-            "version": "==2022.6"
+            "version": "==2022.7"
+        },
+        "pytzdata": {
+            "hashes": [
+                "sha256:3efa13b335a00a8de1d345ae41ec78dd11c9f8807f522d39850f2dd828681540",
+                "sha256:e1e14750bcf95016381e4d472bad004eef710f2d6417240904070b3d6654485f"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2020.1"
         },
         "pyyaml": {
             "hashes": [
@@ -2008,6 +2091,84 @@
             ],
             "markers": "python_version >= '3.7' and python_version < '4'",
             "version": "==2.28.1"
+        },
+        "setproctitle": {
+            "hashes": [
+                "sha256:1c5d5dad7c28bdd1ec4187d818e43796f58a845aa892bb4481587010dc4d362b",
+                "sha256:1c8d9650154afaa86a44ff195b7b10d683c73509d085339d174e394a22cccbb9",
+                "sha256:1f0cde41857a644b7353a0060b5f94f7ba7cf593ebde5a1094da1be581ac9a31",
+                "sha256:1f29b75e86260b0ab59adb12661ef9f113d2f93a59951373eb6d68a852b13e83",
+                "sha256:1fa1a0fbee72b47dc339c87c890d3c03a72ea65c061ade3204f285582f2da30f",
+                "sha256:1ff863a20d1ff6ba2c24e22436a3daa3cd80be1dfb26891aae73f61b54b04aca",
+                "sha256:265ecbe2c6eafe82e104f994ddd7c811520acdd0647b73f65c24f51374cf9494",
+                "sha256:288943dec88e178bb2fd868adf491197cc0fc8b6810416b1c6775e686bab87fe",
+                "sha256:2a97d51c17d438cf5be284775a322d57b7ca9505bb7e118c28b1824ecaf8aeaa",
+                "sha256:2e3ac25bfc4a0f29d2409650c7532d5ddfdbf29f16f8a256fc31c47d0dc05172",
+                "sha256:2fbd8187948284293f43533c150cd69a0e4192c83c377da837dbcd29f6b83084",
+                "sha256:37ece938110cab2bb3957e3910af8152ca15f2b6efdf4f2612e3f6b7e5459b80",
+                "sha256:4058564195b975ddc3f0462375c533cce310ccdd41b80ac9aed641c296c3eff4",
+                "sha256:4749a2b0c9ac52f864d13cee94546606f92b981b50e46226f7f830a56a9dc8e1",
+                "sha256:4bba3be4c1fabf170595b71f3af46c6d482fbe7d9e0563999b49999a31876f77",
+                "sha256:4d8938249a7cea45ab7e1e48b77685d0f2bab1ebfa9dde23e94ab97968996a7c",
+                "sha256:5194b4969f82ea842a4f6af2f82cd16ebdc3f1771fb2771796e6add9835c1973",
+                "sha256:55ce1e9925ce1765865442ede9dca0ba9bde10593fcd570b1f0fa25d3ec6b31c",
+                "sha256:570d255fd99c7f14d8f91363c3ea96bd54f8742275796bca67e1414aeca7d8c3",
+                "sha256:587c7d6780109fbd8a627758063d08ab0421377c0853780e5c356873cdf0f077",
+                "sha256:589be87172b238f839e19f146b9ea47c71e413e951ef0dc6db4218ddacf3c202",
+                "sha256:5b932c3041aa924163f4aab970c2f0e6b4d9d773f4d50326e0ea1cd69240e5c5",
+                "sha256:5fb4f769c02f63fac90989711a3fee83919f47ae9afd4758ced5d86596318c65",
+                "sha256:630f6fe5e24a619ccf970c78e084319ee8be5be253ecc9b5b216b0f474f5ef18",
+                "sha256:65d884e22037b23fa25b2baf1a3316602ed5c5971eb3e9d771a38c3a69ce6e13",
+                "sha256:6c877691b90026670e5a70adfbcc735460a9f4c274d35ec5e8a43ce3f8443005",
+                "sha256:710e16fa3bade3b026907e4a5e841124983620046166f355bbb84be364bf2a02",
+                "sha256:7a55fe05f15c10e8c705038777656fe45e3bd676d49ad9ac8370b75c66dd7cd7",
+                "sha256:7aa0aac1711fadffc1d51e9d00a3bea61f68443d6ac0241a224e4d622489d665",
+                "sha256:7f0bed90a216ef28b9d227d8d73e28a8c9b88c0f48a082d13ab3fa83c581488f",
+                "sha256:7f2719a398e1a2c01c2a63bf30377a34d0b6ef61946ab9cf4d550733af8f1ef1",
+                "sha256:7fe9df7aeb8c64db6c34fc3b13271a363475d77bc157d3f00275a53910cb1989",
+                "sha256:88486e6cce2a18a033013d17b30a594f1c5cb42520c49c19e6ade40b864bb7ff",
+                "sha256:8e4f8f12258a8739c565292a551c3db62cca4ed4f6b6126664e2381acb4931bf",
+                "sha256:8ff3c8cb26afaed25e8bca7b9dd0c1e36de71f35a3a0706b5c0d5172587a3827",
+                "sha256:9124bedd8006b0e04d4e8a71a0945da9b67e7a4ab88fdad7b1440dc5b6122c42",
+                "sha256:92c626edc66169a1b09e9541b9c0c9f10488447d8a2b1d87c8f0672e771bc927",
+                "sha256:a149a5f7f2c5a065d4e63cb0d7a4b6d3b66e6e80f12e3f8827c4f63974cbf122",
+                "sha256:a47d97a75fd2d10c37410b180f67a5835cb1d8fdea2648fd7f359d4277f180b9",
+                "sha256:a499fff50387c1520c085a07578a000123f519e5f3eee61dd68e1d301659651f",
+                "sha256:a8e0881568c5e6beff91ef73c0ec8ac2a9d3ecc9edd6bd83c31ca34f770910c4",
+                "sha256:ab45146c71ca6592c9cc8b354a2cc9cc4843c33efcbe1d245d7d37ce9696552d",
+                "sha256:b2c9cb2705fc84cb8798f1ba74194f4c080aaef19d9dae843591c09b97678e98",
+                "sha256:b34baef93bfb20a8ecb930e395ccd2ae3268050d8cf4fe187de5e2bd806fd796",
+                "sha256:b617f12c9be61e8f4b2857be4a4319754756845dbbbd9c3718f468bbb1e17bcb",
+                "sha256:b9fb97907c830d260fa0658ed58afd48a86b2b88aac521135c352ff7fd3477fd",
+                "sha256:bae283e85fc084b18ffeb92e061ff7ac5af9e183c9d1345c93e178c3e5069cbe",
+                "sha256:c2c46200656280a064073447ebd363937562debef329482fd7e570c8d498f806",
+                "sha256:c8a09d570b39517de10ee5b718730e171251ce63bbb890c430c725c8c53d4484",
+                "sha256:c91b9bc8985d00239f7dc08a49927a7ca1ca8a6af2c3890feec3ed9665b6f91e",
+                "sha256:ca58cd260ea02759238d994cfae844fc8b1e206c684beb8f38877dcab8451dfc",
+                "sha256:d7d17c8bd073cbf8d141993db45145a70b307385b69171d6b54bcf23e5d644de",
+                "sha256:dad42e676c5261eb50fdb16bdf3e2771cf8f99a79ef69ba88729aeb3472d8575",
+                "sha256:db684d6bbb735a80bcbc3737856385b55d53f8a44ce9b46e9a5682c5133a9bf7",
+                "sha256:de3a540cd1817ede31f530d20e6a4935bbc1b145fd8f8cf393903b1e02f1ae76",
+                "sha256:e00c9d5c541a2713ba0e657e0303bf96ddddc412ef4761676adc35df35d7c246",
+                "sha256:e1aafc91cbdacc9e5fe712c52077369168e6b6c346f3a9d51bf600b53eae56bb",
+                "sha256:e425be62524dc0c593985da794ee73eb8a17abb10fe692ee43bb39e201d7a099",
+                "sha256:e43f315c68aa61cbdef522a2272c5a5b9b8fd03c301d3167b5e1343ef50c676c",
+                "sha256:e49ae693306d7624015f31cb3e82708916759d592c2e5f72a35c8f4cc8aef258",
+                "sha256:e5c50e164cd2459bc5137c15288a9ef57160fd5cbf293265ea3c45efe7870865",
+                "sha256:e8579a43eafd246e285eb3a5b939e7158073d5087aacdd2308f23200eac2458b",
+                "sha256:e85e50b9c67854f89635a86247412f3ad66b132a4d8534ac017547197c88f27d",
+                "sha256:e932089c35a396dc31a5a1fc49889dd559548d14cb2237adae260382a090382e",
+                "sha256:f0452282258dfcc01697026a8841258dd2057c4438b43914b611bccbcd048f10",
+                "sha256:f4bfc89bd33ebb8e4c0e9846a09b1f5a4a86f5cb7a317e75cc42fee1131b4f4f",
+                "sha256:fa2f50678f04fda7a75d0fe5dd02bbdd3b13cbe6ed4cf626e4472a7ccf47ae94",
+                "sha256:faec934cfe5fd6ac1151c02e67156c3f526e82f96b24d550b5d51efa4a5527c6",
+                "sha256:fcd3cf4286a60fdc95451d8d14e0389a6b4f5cebe02c7f2609325eb016535963",
+                "sha256:fe8a988c7220c002c45347430993830666e55bc350179d91fcee0feafe64e1d4",
+                "sha256:fed18e44711c5af4b681c2b3b18f85e6f0f1b2370a28854c645d636d5305ccd8",
+                "sha256:ffc61a388a5834a97953d6444a2888c24a05f2e333f9ed49f977a87bb1ad4761"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.3.2"
         },
         "six": {
             "hashes": [
@@ -2111,12 +2272,31 @@
             "markers": "python_version >= '3.5'",
             "version": "==1.1.5"
         },
+        "sqlparse": {
+            "hashes": [
+                "sha256:0323c0ec29cd52bceabc1b4d9d579e311f3e4961b98d174201d5622a23b85e34",
+                "sha256:69ca804846bb114d2ec380e4360a8a340db83f0ccf3afceeb1404df028f57268"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==0.4.3"
+        },
         "stack-data": {
             "hashes": [
                 "sha256:32d2dd0376772d01b6cb9fc996f3c8b57a357089dec328ed4b6553d037eaf815",
                 "sha256:cbb2a53eb64e5785878201a97ed7c7b94883f48b87bfb0bbe8b623c74679e4a8"
             ],
             "version": "==0.6.2"
+        },
+        "tabulate": {
+            "extras": [
+                "widechars"
+            ],
+            "hashes": [
+                "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c",
+                "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.9.0"
         },
         "tomli": {
             "hashes": [
@@ -2140,16 +2320,16 @@
                 "sha256:d3a2f5999215a3a06a4fc218026cd84c61b8b2b40ac5296a6db1f1451ef04c1e",
                 "sha256:e5f923aa6a47e133d1cf87d60700889d7eae68988704e20c75fb2d65677a8e4b"
             ],
-            "markers": "python_version > '2.7'",
+            "markers": "python_version >= '3.7'",
             "version": "==6.2"
         },
         "traitlets": {
             "hashes": [
-                "sha256:57ba2ba951632eeab9388fa45f342a5402060a5cc9f0bb942f760fafb6641581",
-                "sha256:fde8f62c05204ead43c2c1b9389cfc85befa7f54acb5da28529d671175bb4108"
+                "sha256:6cc57d6dc28c85d5365961726ffd19b538739347749e13ebe34e03323a0e8f84",
+                "sha256:c864831efa0ba6576d09b44884b34e41defc18c0d7e720b4a2d6698c842cab3e"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==5.7.1"
+            "version": "==5.8.0"
         },
         "typing-extensions": {
             "hashes": [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,6 @@ services:
       MEDIA_ROOT: ${MEDIA_ROOT:-}
     stdin_open: true
     tty: true
-    user: ${DOCKER_USER_ID}:${DOCKER_GROUP_ID}
 
   ingestion_server:
     build: ./ingestion_server/

--- a/justfile
+++ b/justfile
@@ -262,9 +262,13 @@ nginx upstream_url='api.openverse.engineering': collectstatic
       -e DJANGO_NGINX_GIT_REVISION="$(git rev-parse HEAD)" \
       openverse-api-nginx:latest
 
-# Launch a pgcli shell on the web container
-db-shell db_host="db":
-    docker-compose {{ DOCKER_FILE }} exec web pgcli -h {{ db_host }} openledger deploy
+# Launch a psql shell in the web container
+@dbshell:
+    just exec web python manage.py dbshell
+
+# Launch a pgcli shell in the web container (require typing credentials)
+@pgcli db_host="db":
+    just exec web pgcli -h {{ db_host }} openledger deploy
 
 
 ##########

--- a/justfile
+++ b/justfile
@@ -262,8 +262,8 @@ nginx upstream_url='api.openverse.engineering': collectstatic
       openverse-api-nginx:latest
 
 # Launch a pgcli shell on the web container
-db-shell: _api-up
-    docker-compose {{ DOCKER_FILE }} exec web pgcli openledger deploy
+db-shell db_host="db":
+    docker-compose {{ DOCKER_FILE }} exec web pgcli -h {{ db_host }} openledger deploy
 
 
 ##########

--- a/justfile
+++ b/justfile
@@ -247,6 +247,9 @@ ipython:
     # The resulting output will be at `api/static` and is git ignored for convenience.
     @STATIC_ROOT="./static" just dj collectstatic --noinput
 
+@collectstatic-as-admin: _api-up
+    just exec -u root web python manage.py collectstatic --noinput
+
 # Run the nginx image locally
 nginx upstream_url='api.openverse.engineering': collectstatic
     # upstream_url can also be set to 172.17.0.1:50280 for local testing

--- a/justfile
+++ b/justfile
@@ -248,9 +248,6 @@ ipython:
     # The resulting output will be at `api/static` and is git ignored for convenience.
     @STATIC_ROOT="./static" just dj collectstatic --noinput
 
-@collectstatic-as-admin: _api-up
-    just exec -u root web python manage.py collectstatic --noinput
-
 # Run the nginx image locally
 nginx upstream_url='api.openverse.engineering': collectstatic
     # upstream_url can also be set to 172.17.0.1:50280 for local testing

--- a/justfile
+++ b/justfile
@@ -2,6 +2,7 @@ set dotenv-load := false
 
 IS_PROD := env_var_or_default("PROD", "")
 IS_CI := env_var_or_default("CI", "")
+DC_USER := env_var_or_default("DC_USER", "opener")
 
 # Show all available recipes
 default:
@@ -66,7 +67,7 @@ EXEC_DEFAULTS := if IS_CI == "" { "" } else { "-T" }
 
 # Execute statement in service containers using Docker Compose
 exec +args:
-    docker-compose exec {{ EXEC_DEFAULTS }} {{ args }}
+    docker-compose exec -u {{ DC_USER }} {{ EXEC_DEFAULTS }} {{ args }}
 
 ########
 # Init #
@@ -245,7 +246,7 @@ ipython:
     # The `STATIC_ROOT` setting is relative to the directory in which the Django
     # container runs (i.e., the `api` directory at the root of the repository).
     # The resulting output will be at `api/static` and is git ignored for convenience.
-    @STATIC_ROOT="./static" just dj collectstatic --noinput
+    @STATIC_ROOT="./static" DC_USER=root just dj collectstatic --noinput
 
 @collectstatic-as-admin: _api-up
     just exec -u root web python manage.py collectstatic --noinput

--- a/justfile
+++ b/justfile
@@ -261,6 +261,10 @@ nginx upstream_url='api.openverse.engineering': collectstatic
       -e DJANGO_NGINX_GIT_REVISION="$(git rev-parse HEAD)" \
       openverse-api-nginx:latest
 
+# Launch a pgcli shell on the web container
+db-shell: _api-up
+    docker-compose {{ DOCKER_FILE }} exec web pgcli openledger deploy
+
 
 ##########
 # Sphinx #

--- a/justfile
+++ b/justfile
@@ -32,9 +32,6 @@ DOCKER_FILE := "-f " + (
     else { "docker-compose.yml" }
 )
 
-export DOCKER_USER_ID := `id -u`
-export DOCKER_GROUP_ID := `id -g`
-
 # Run `docker-compose` configured with the correct files and environment
 dc *args:
     docker-compose {{ DOCKER_FILE }} {{ args }}

--- a/justfile
+++ b/justfile
@@ -246,7 +246,7 @@ ipython:
     # The `STATIC_ROOT` setting is relative to the directory in which the Django
     # container runs (i.e., the `api` directory at the root of the repository).
     # The resulting output will be at `api/static` and is git ignored for convenience.
-    @STATIC_ROOT="./static" DC_USER=root just dj collectstatic --noinput
+    @STATIC_ROOT="./static" just dj collectstatic --noinput
 
 @collectstatic-as-admin: _api-up
     just exec -u root web python manage.py collectstatic --noinput


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Related to #952 by @zackkrida in the sense that, if I remember correctly, it was driven by a difficulty presented to @stacimc to connect to the API DB.

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR:
- installs `pgcli` as dev dependency
- adds a `just dbshell` _and_ `just pgcli` commands, taking inspiration from [the one in the catalog repository](https://github.com/WordPress/openverse-catalog/blob/main/justfile#L115-L117) and using the provided[ django command](https://docs.djangoproject.com/en/4.1/ref/django-admin/#dbshell) as well
- adds a non-root `opener` user to the `web` container, removing the tricky pass of the host user, it wasn't working well in macOS, so I believe creating a proper user is the best route we can follow
- adds `GITHUB_TOKEN` to steps so setup just, it's necessary to prevent rate limiting errors (as [said in docs](https://github.com/extractions/setup-just#usage))
- bumps action dependencies to prevent warnings on deprecated commands

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. `just up` & `just db-shell` 
2. Enter the development password: `deploy`
3. You should be able to make queries in the pgcli console

If you try these commands at the commit `2c1c7246dbf019c2cf1747211273923fa2e50826`, without the user created internally, you will notice it fails (at least on macOS).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
