### PR TITLE
Allow `/version` to be defined by environment variables

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -48,7 +48,9 @@ WORKDIR /app
 COPY nginx.conf.template /etc/nginx/templates/openverse-api.conf.template
 COPY /static /app/static
 
-ENV NGINX_ENVSUBST_FILTER="DJANGO_UPSTREAM_URL"
+# Only environment variables with this prefix will be available in the template
+ENV NGINX_ENVSUBST_FILTER="DJANGO_NGINX_"
+ENV DJANGO_NGINX_ENVIRONMENT="local"
 
 #######
 # API #

--- a/api/nginx.conf.template
+++ b/api/nginx.conf.template
@@ -2,18 +2,18 @@ error_log /var/log/nginx/error.log;
 
 log_format json_combined escape=json
     '{'
-    '"time_local":"\$time_local",'
-    '"remote_addr":"\$remote_addr",'
-    '"remote_user":"\$remote_user",'
-    '"request":"\$request",'
-    '"status": "\$status",'
-    '"host_header": "\$host",'
-    '"body_bytes_sent":\$body_bytes_sent,'
-    '"request_time":"\$request_time",'
-    '"http_referrer":"\$http_referer",'
-    '"http_user_agent":"\$http_user_agent",'
-    '"upstream_response_time":\$upstream_response_time,'
-    '"http_x_forwarded_for":"\$http_x_forwarded_for"'
+    '"time_local":"$time_local",'
+    '"remote_addr":"$remote_addr",'
+    '"remote_user":"$remote_user",'
+    '"request":"$request",'
+    '"status": "$status",'
+    '"host_header": "$host",'
+    '"body_bytes_sent":$body_bytes_sent,'
+    '"request_time":"$request_time",'
+    '"http_referrer":"$http_referer",'
+    '"http_user_agent":"$http_user_agent",'
+    '"upstream_response_time":$upstream_response_time,'
+    '"http_x_forwarded_for":"$http_x_forwarded_for"'
     '}';
 
 access_log  /var/log/nginx/access.log  json_combined;
@@ -51,18 +51,18 @@ server {
     }
 
     location / {
-        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto \$scheme;
-        proxy_set_header Host \$http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $http_host;
         proxy_redirect off;
         proxy_pass http://django;
         error_page 500 /500.json;
     }
 
     location ~ ^/(v1|admin)/ {
-        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto \$scheme;
-        proxy_set_header Host \$http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $http_host;
         proxy_redirect off;
         proxy_pass http://django;
         error_page 500 /500.json;

--- a/api/nginx.conf.template
+++ b/api/nginx.conf.template
@@ -1,3 +1,10 @@
+# The following variables are substituted into the environment using envsubst.
+# This occurs automatically as part of the nginx image startup.
+# See: https://github.com/nginxinc/docker-nginx/blob/456bf337ceb922a207651aa7c6077a316c3e368c/entrypoint/20-envsubst-on-templates.sh#L17
+# - DJANGO_NGINX_UPSTREAM_URL
+# - DJANGO_NGINX_GIT_REVISION
+# - DJANGO_NGINX_ENVIRONMENT
+
 error_log /var/log/nginx/error.log;
 
 log_format json_combined escape=json
@@ -31,8 +38,7 @@ gzip_types application/json text/plain application/javascript;
 gzip_disable "MSIE [1-6]\.";
 
 upstream django {
-    # DJANGO_UPSTREAM_URL must be substituted using a tool like envsubst
-    server          $DJANGO_UPSTREAM_URL;
+    server          $DJANGO_NGINX_UPSTREAM_URL;
 }
 
 server {
@@ -80,6 +86,6 @@ server {
 
     location /version {
         default_type "application/json";
-        alias /var/api/version.json;
+        return 200 '{"release": "$DJANGO_NGINX_GIT_REVISION", "environment": "$DJANGO_NGINX_ENVIRONMENT"}';
     }
 }

--- a/justfile
+++ b/justfile
@@ -231,11 +231,19 @@ ipython:
     just dj shell
 
 # Run `collectstatic` to prepare for building the `nginx` Dockerfile target.
-@collectstatic: _api-up
+@collectstatic:
     # The `STATIC_ROOT` setting is relative to the directory in which the Django
     # container runs (i.e., the `api` directory at the root of the repository).
     # The resulting output will be at `api/static` and is git ignored for convenience.
     @STATIC_ROOT="./static" just dj collectstatic --noinput
+
+# Run the nginx image locally
+nginx upstream_url='api.openverse.engineering': collectstatic
+    # upstream_url can also be set to 172.17.0.1:50280 for local testing
+    cd api && docker build --target nginx . -t openverse-api-nginx:latest
+    echo "--> NGINX server will be run at http://localhost:9090, upstream at {{ upstream_url }}"
+    echo "--> Try a static URL like http://localhost:9090/static/admin/css/base.css to test"
+    docker run --rm -p 9090:8080 -e DJANGO_UPSTREAM_URL='{{ upstream_url }}' -it openverse-api-nginx:latest
 
 
 ##########

--- a/justfile
+++ b/justfile
@@ -241,9 +241,12 @@ ipython:
 nginx upstream_url='api.openverse.engineering': collectstatic
     # upstream_url can also be set to 172.17.0.1:50280 for local testing
     cd api && docker build --target nginx . -t openverse-api-nginx:latest
-    echo "--> NGINX server will be run at http://localhost:9090, upstream at {{ upstream_url }}"
-    echo "--> Try a static URL like http://localhost:9090/static/admin/css/base.css to test"
-    docker run --rm -p 9090:8080 -e DJANGO_UPSTREAM_URL='{{ upstream_url }}' -it openverse-api-nginx:latest
+    @echo "--> NGINX server will be run at http://localhost:9090, upstream at {{ upstream_url }}"
+    @echo "--> Try a static URL like http://localhost:9090/static/admin/css/base.css to test"
+    docker run --rm -p 9090:8080 -it \
+      -e DJANGO_NGINX_UPSTREAM_URL="{{ upstream_url }}" \
+      -e DJANGO_NGINX_GIT_REVISION="$(git rev-parse HEAD)" \
+      openverse-api-nginx:latest
 
 
 ##########


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
This is necessary for continued work on https://github.com/WordPress/openverse-infrastructure/issues/175

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
This PR makes a few changes to the nginx target image for the API in order to prevent the need for mounting any files into the docker container. Previously, the `/version` was configured to return the contents of a `version.json` file. This file was created during deployment and mounted into the nginx image:

https://github.com/WordPress/openverse-infrastructure/blob/369d7858636797de276dbfc299b90b822a5ac527/modules/services/openverse-api/init.tpl#L79-L85

The issue with this is that we are trying to avoid the need for mounting anything into our API-related containers. This was the last necessary item that was being mounted. You can see that this endpoint is not served by the API by running `just up` and visiting http://localhost:50280/version. 

I've altered the image to construct the response from `/version` using environment variables rather than reading from a file on-disk. This involved a few changes to the environment substitution setup, which I was unfamiliar with (there are seemingly no references to `NGINX_ENVSUBST_FILTER` on GitHub where it's being defined by anyone other than us!). I added a few more comments to try and provide reference to what was being used, and where.

I also addressed an issue wherein we were erroneously referencing variables inside the nginx template with `\$` rather than just `$`. This was an artifact of constructing the config inside of the `init.tpl` file during deployment (which required that we escape the `$` character since it was used for its own interpolation). This was producing logs that looked like the following (note the extra `\` characters before field values):

> ` {"time_local":"\29/Nov/2022:00:33:08 +0000","remote_addr":"\172.17.0.1","remote_user":"\","request":"\GET / HTTP/1.1","status": "\400","host_header": "\localhost","body_bytes_sent":\155,"request_time":"\0.020","http_referrer":"\","http_user_agent":"\Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:106.0) Gecko/20100101 Firefox/106.0","upstream_response_time":\0.020,"http_x_forwarded_for":"\"}`

Lastly, I added a `just` recipe for running the nginx image locally with some suggestions on how to test that it works.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. Before checking out this branch, verify that the API returns a 404 on http://localhost:50280/version after running `just up`
1. Run `just nginx`
1. Visit http://localhost:9090/static/admin/css/base.css and verify that results are returned (this should be from api.openverse.engineering)
1. Visit http://localhost:9090/version and verify that you receive something similar to the following:

```json
{

    "release": "47521cd5b288c35afaf0f996015e8122bbc1ccf8",
    "environment": "local"

}
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
