### PR TITLE
Handle `asyncio.TimeoutError` for link validation code

### DIFF
--- a/api/test/unit/utils/validate_images_test.py
+++ b/api/test/unit/utils/validate_images_test.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest import mock
 
 import aiohttp
@@ -43,4 +44,27 @@ def test_sends_user_agent(wrapped_client_session: mock.AsyncMock):
     for url in image_urls:
         assert url in requested_urls
 
-    wrapped_client_session.assert_called_once_with(headers=HEADERS)
+    wrapped_client_session.assert_called_once_with(headers=HEADERS, timeout=mock.ANY)
+
+
+def test_handles_timeout():
+    """
+    Note: This test takes just over 3 seconds to run as it simulates network delay of 3 seconds.
+    """
+    query_hash = "test_handles_timeout"
+    results = [{"identifier": i} for i in range(1)]
+    image_urls = [f"https://example.org/{i}" for i in range(len(results))]
+    start_slice = 0
+
+    def raise_timeout_error(*args, **kwargs):
+        raise asyncio.TimeoutError()
+
+    with mock.patch(
+        "aiohttp.client.ClientSession._request", side_effect=raise_timeout_error
+    ):
+        validate_images(query_hash, start_slice, results, image_urls)
+
+    # `validate_images` directly modifies the results list
+    # if the results are timing out then they're considered dead and discarded
+    # so should not appear in the final list of results.
+    assert len(results) == 0


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes https://sentry.io/share/issue/bc0a4a1acfba45b6a8daca58a8e39ef2/ (which originated from #1027)

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Handles the TimeoutError when it is raised as it is not part of ClientError.

We tested the timeout configuration in ipython manually to confirm that it works in actual network scenarios:

```
In [3]: import aiohttp

In [4]: timeout = aiohttp.ClientTimeout(total=2)

In [5]: async with aiohttp.ClientSession(timeout=timeout) as session:
   ...:     await session.get("https://httpbin.org/delay/3")
   ...: 
---------------------------------------------------------------------------
TimeoutError                              Traceback (most recent call last)
Cell In[5], line 2
      1 async with aiohttp.ClientSession(timeout=timeout) as session:
----> 2     await session.get("https://httpbin.org/delay/3")

File ~venv/lib/python3.10/site-packages/aiohttp/client.py:560, in ClientSession._request(self, method, str_or_url, params, data, json, cookies, headers, skip_auto_headers, auth, allow_redirects, max_redirects, compress, chunked, expect100, raise_for_status, read_until_eof, proxy, proxy_auth, timeout, verify_ssl, fingerprint, ssl_context, ssl, proxy_headers, trace_request_ctx, read_bufsize)
    558 resp = await req.send(conn)
    559 try:
--> 560     await resp.start(conn)
    561 except BaseException:
    562     resp.close()

File ~venv/lib/python3.10/site-packages/aiohttp/client_reqrep.py:894, in ClientResponse.start(self, connection)
    891 self._protocol = connection.protocol
    892 self._connection = connection
--> 894 with self._timer:
    895     while True:
    896         # read response
    897         try:

File ~venv/lib/python3.10/site-packages/aiohttp/helpers.py:720, in TimerContext.__exit__(self, exc_type, exc_val, exc_tb)
    717     self._tasks.pop()
    719 if exc_type is asyncio.CancelledError and self._cancelled:
--> 720     raise asyncio.TimeoutError from None
    721 return None

TimeoutError: 
```

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Check out the new unit test and confirm that it makes sense. Also check out the ipython above and try it out yourself if you want to confirm that the timeout configuration actually works in real network situations.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [N/A] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
