### PR TITLE
Create pre-filtered secondary indexes and add ability to automatically filter sensitive terms at query time

### DIFF
--- a/api/catalog/api/controllers/search_controller.py
+++ b/api/catalog/api/controllers/search_controller.py
@@ -13,7 +13,7 @@ from rest_framework.request import Request
 
 from elasticsearch.exceptions import NotFoundError, RequestError
 from elasticsearch_dsl import Q, Search
-from elasticsearch_dsl.query import EMPTY_QUERY, MoreLikeThis, Query
+from elasticsearch_dsl.query import EMPTY_QUERY, MoreLikeThis, MultiMatch, Query
 from elasticsearch_dsl.response import Hit, Response
 
 import catalog.api.models as models
@@ -345,6 +345,10 @@ def search(
             "fields": search_fields,
             "default_operator": "AND",
         }
+
+        if not search_params.data["mature"]:
+            for t in settings.SENSITIVE_TERMS:
+                s = s.query(~MultiMatch(query=t, fields=search_fields))
 
         if '"' in query:
             base_query_kwargs["quote_field_suffix"] = ".exact"

--- a/api/catalog/settings.py
+++ b/api/catalog/settings.py
@@ -385,8 +385,11 @@ BASE_URL = config("BASE_URL", default="https://wordpress.org/openverse/")
 # Keeping this as an environment variable allows us to avoid publishing a list
 # of "sensitive terms" in our normal application repository, decoupling a
 # complex issue from the rest of the codebase.
+# When editing this list, cross-reference it with the list of default sensitive terms
+# used in the ingestion server (found in ingestion_server/env.docker) and
+# ensure they're different so that testing each one is distinct.
 SENSITIVE_TERMS = config(
     "SENSITIVE_TERMS",
     cast=lambda x: (t.strip() for t in x.split(",")),
-    default="dog, water" if ENVIRONMENT in ["local", "development"] else "",
+    default="spoiled, perched" if ENVIRONMENT in ["local", "development"] else "",
 )

--- a/api/catalog/settings.py
+++ b/api/catalog/settings.py
@@ -390,6 +390,6 @@ BASE_URL = config("BASE_URL", default="https://wordpress.org/openverse/")
 # ensure they're different so that testing each one is distinct.
 SENSITIVE_TERMS = config(
     "SENSITIVE_TERMS",
-    cast=lambda x: (t.strip() for t in x.split(",")),
+    cast=lambda x: tuple(t.strip() for t in x.split(",")),
     default="spoiled, perched" if ENVIRONMENT in ["local", "development"] else "",
 )

--- a/api/catalog/settings.py
+++ b/api/catalog/settings.py
@@ -388,5 +388,5 @@ BASE_URL = config("BASE_URL", default="https://wordpress.org/openverse/")
 SENSITIVE_TERMS = config(
     "SENSITIVE_TERMS",
     cast=lambda x: (t.strip() for t in x.split(",")),
-    default="dog, water" if ENVIRONMENT == "local" else "",
+    default="dog, water" if ENVIRONMENT in ["local", "development"] else "",
 )

--- a/api/catalog/settings.py
+++ b/api/catalog/settings.py
@@ -381,3 +381,12 @@ MAX_AUTHED_PAGE_SIZE = 500
 MAX_PAGINATION_DEPTH = 20
 
 BASE_URL = config("BASE_URL", default="https://wordpress.org/openverse/")
+
+# Keeping this as an environment variable allows us to avoid publishing a list
+# of "sensitive terms" in our normal application repository, decoupling a
+# complex issue from the rest of the codebase.
+SENSITIVE_TERMS = config(
+    "SENSITIVE_TERMS",
+    cast=lambda x: (t.strip() for t in x.split(",")),
+    default="dog, water" if ENVIRONMENT == "local" else "",
+)

--- a/api/test/audio_integration_test.py
+++ b/api/test/audio_integration_test.py
@@ -52,7 +52,7 @@ def force_result_validity():
 
 @pytest.fixture
 def audio_fixture(force_result_validity):
-    res = requests.get(f"{API_URL}/v1/audio/", verify=False)
+    res = requests.get(f"{API_URL}/v1/audio/?mature=True", verify=False)
     parsed = res.json()
     force_result_validity(parsed)
     assert res.status_code == 200

--- a/api/test/image_integration_test.py
+++ b/api/test/image_integration_test.py
@@ -34,7 +34,7 @@ identifier = "cdbd3bf6-1745-45bb-b399-61ee149cd58a"
 
 @pytest.fixture
 def image_fixture():
-    response = requests.get(f"{API_URL}/v1/images?q=dog", verify=False)
+    response = requests.get(f"{API_URL}/v1/images?q=dog&mature=True", verify=False)
     assert response.status_code == 200
     parsed = json.loads(response.text)
     return parsed

--- a/api/test/media_integration.py
+++ b/api/test/media_integration.py
@@ -45,8 +45,7 @@ def search_quotes(media_path, q="test"):
     """Return a response when quote matching is messed up."""
 
     response = requests.get(
-        f'{API_URL}/v1/{media_path}?q="{q}&mature=True',
-        verify=False
+        f'{API_URL}/v1/{media_path}?q="{q}&mature=True', verify=False
     )
     assert response.status_code == 200
 

--- a/api/test/media_integration.py
+++ b/api/test/media_integration.py
@@ -44,14 +44,17 @@ def search_source_and_excluded(media_path):
 def search_quotes(media_path, q="test"):
     """Return a response when quote matching is messed up."""
 
-    response = requests.get(f'{API_URL}/v1/{media_path}?q="{q}', verify=False)
+    response = requests.get(
+        f'{API_URL}/v1/{media_path}?q="{q}&mature=True',
+        verify=False
+    )
     assert response.status_code == 200
 
 
 def search_quotes_exact(media_path, q):
     """Return only exact matches for the given query."""
 
-    url_format = f"{API_URL}/v1/{media_path}?q={{q}}"
+    url_format = f"{API_URL}/v1/{media_path}?q={{q}}&mature=True"
     unquoted_response = requests.get(url_format.format(q=q), verify=False)
     assert unquoted_response.status_code == 200
     unquoted_result_count = unquoted_response.json()["result_count"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,7 @@ services:
       - ./ingestion_server:/ingestion_server
     env_file:
       - ingestion_server/env.docker
+      - ingestion_server/.env
     stdin_open: true
     tty: true
 

--- a/ingestion_server/env.docker
+++ b/ingestion_server/env.docker
@@ -11,3 +11,6 @@ LOCK_PATH="/worker_state/lock"
 SHELF_PATH="/worker_state/db"
 
 INDEXER_WORKER_HOST="indexer_worker"
+
+# Terms just for testing
+SENSITIVE_TERMS="dog,water"

--- a/ingestion_server/ingestion_server/es_mapping.py
+++ b/ingestion_server/ingestion_server/es_mapping.py
@@ -2,6 +2,9 @@ def index_settings(table_name):
     """
     Return the Elasticsearch mapping for a given table in the database.
 
+    These mappings are used for both the "sensitive" and "full" (unaltered)
+    index aliases.
+
     :param table_name: The name of the table in the upstream database.
     :return:
     """

--- a/ingestion_server/ingestion_server/indexer.py
+++ b/ingestion_server/ingestion_server/indexer.py
@@ -57,6 +57,10 @@ REP_TABLES = config(
     "COPY_TABLES", default="image", cast=lambda var: [s.strip() for s in var.split(",")]
 )
 
+SENSITIVE_TERMS = config(
+    "SENSITIVE_TERMS", default="", cast=lambda x: (t.strip() for t in x.split(","))
+)
+
 
 def database_connect(autocommit=False):
     """
@@ -309,6 +313,38 @@ class TableIndexer:
         schedule_distributed_index(
             database_connect(), model_name, table_name, destination_index, self.task_id
         )
+
+    def create_filtered_index(self, model_name: str, index_suffix: str, **_):
+        """
+        Create a secondary index that excludes documents filtered by a list of terms.
+        """
+
+        source_index = f"{model_name}-{index_suffix}"
+        destination_index = f"{source_index}-filtered"
+
+        log.info(f"Creating filtered index '{destination_index}' from '{source_index}'")
+        self.es.reindex(
+            body={
+                "source": {
+                    "index": source_index,
+                    "query": {
+                        "bool": {
+                            "must_not": [
+                                {
+                                    "multi_match": {
+                                        "query": term,
+                                        "fields": ["tags.name", "title", "description"],
+                                    }
+                                }
+                                for term in SENSITIVE_TERMS
+                            ]
+                        }
+                    },
+                },
+                "dest": {"index": destination_index},
+            }
+        )
+        self.ping_callback()
 
     def update_index(self, model_name: str, index_suffix: str, since_date: str, **_):
         """

--- a/ingestion_server/ingestion_server/indexer.py
+++ b/ingestion_server/ingestion_server/indexer.py
@@ -316,7 +316,10 @@ class TableIndexer:
 
     def create_filtered_index(self, model_name: str, index_suffix: str, **_):
         """
-        Create a secondary index that excludes documents filtered by a list of terms.
+        Create a secondary index that excludes documents by a list of sensitive terms.
+
+        :param model_name: the name of the media type
+        :param index_suffix: the unique suffix to add to the index name
         """
 
         source_index = f"{model_name}-{index_suffix}"

--- a/ingestion_server/ingestion_server/indexer.py
+++ b/ingestion_server/ingestion_server/indexer.py
@@ -344,6 +344,7 @@ class TableIndexer:
                 "dest": {"index": destination_index},
             }
         )
+        self.refresh(index_name=destination_index, change_settings=True)
         self.ping_callback()
 
     def update_index(self, model_name: str, index_suffix: str, since_date: str, **_):

--- a/ingestion_server/ingestion_server/tasks.py
+++ b/ingestion_server/ingestion_server/tasks.py
@@ -54,6 +54,10 @@ class TaskTypes(Enum):
     """create indices in ES for QA tests; this is not intended to run in production but
     can be run without negative consequences"""
 
+    CREATE_FILTERED_INDEX = auto()
+    """create a filtered index excluding documents matching sensitive terms
+    from an existing index"""
+
     def __str__(self):
         """
         Get the string representation of this enum.

--- a/ingestion_server/test/integration_test.py
+++ b/ingestion_server/test/integration_test.py
@@ -264,6 +264,38 @@ class TestIngestion(unittest.TestCase):
         es = self._get_es()
         assert list(es.indices.get(index=alias).keys())[0] == f"{model}-{suffix}"
 
+    def _create_filtered_index(self, model, suffix="integration"):
+        req = {
+            "model": model,
+            "action": "CREATE_FILTERED_INDEX",
+            "index_suffix": suffix,
+            "callback_url": bottle_url,
+        }
+        res = requests.post(f"{ingestion_server}/task", json=req)
+
+        stat_msg = "The job should launch successfully and return 202 ACCEPTED."
+        self.assertEqual(res.status_code, 202, msg=stat_msg)
+
+        # Wait for the task to send us a callback.
+        assert self.__class__.cb_queue.get(timeout=120) == "CALLBACK!"
+
+        self.check_index_exists(f"{model}-{suffix}-filtered")
+
+    def _point_alias(self, model, suffix, alias):
+        req = {
+            "model": model,
+            "action": "POINT_ALIAS",
+            "index_suffix": suffix,
+            "alias": alias,
+            "callback_url": bottle_url,
+        }
+        res = requests.post(f"{ingestion_server}/task", json=req)
+
+        stat_msg = "The job should launch successfully and return 202 ACCEPTED."
+        self.assertEqual(res.status_code, 202, msg=stat_msg)
+
+        self.check_index_exists(alias)
+
     def _delete_index(self, model, suffix="integration", alias=None):
         req = {
             "model": model,
@@ -393,22 +425,22 @@ class TestIngestion(unittest.TestCase):
         msg = "There should be no tasks in the task list"
         self.assertEqual(res_json, [], msg)
 
-    @pytest.mark.order(2)
+    @pytest.mark.order(after="test_list_tasks_empty")
     def test_image_ingestion_succeeds(self):
         self._ingest_upstream("image", "integration")
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(after="test_image_ingestion_succeeds")
     def test_task_count_after_one(self):
         res = requests.get(f"{ingestion_server}/task")
         res_json = res.json()
         msg = "There should be one task in the task list now."
         self.assertEqual(1, len(res_json), msg)
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(after="test_task_count_after_one")
     def test_audio_ingestion_succeeds(self):
         self._ingest_upstream("audio", "integration")
 
-    @pytest.mark.order(5)
+    @pytest.mark.order(after="test_audio_ingestion_succeeds")
     def test_task_count_after_two(self):
         res = requests.get(f"{ingestion_server}/task")
         res_json = res.json()
@@ -427,15 +459,15 @@ class TestIngestion(unittest.TestCase):
             wait_for_status="yellow",
         )
 
-    @pytest.mark.order(6)
+    @pytest.mark.order(after="test_task_count_after_two")
     def test_promote_images(self):
         self._promote("image", "integration", "image-main")
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(after="test_promote_images")
     def test_promote_audio(self):
         self._promote("audio", "integration", "audio-main")
 
-    @pytest.mark.order(8)
+    @pytest.mark.order(after="test_promote_audio")
     def test_upstream_indexed_images(self):
         """
         Check that the image data has been successfully indexed in Elasticsearch.
@@ -450,7 +482,7 @@ class TestIngestion(unittest.TestCase):
         msg = "There should be 5000 images in Elasticsearch after ingestion."
         self.assertEqual(count, 5000, msg)
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(after="test_upstream_indexed_images")
     def test_upstream_indexed_audio(self):
         """
         Check that the audio data has been successfully indexed in Elasticsearch.
@@ -465,7 +497,7 @@ class TestIngestion(unittest.TestCase):
         msg = "There should be 5000 audio tracks in Elasticsearch after ingestion."
         self.assertEqual(count, 5000, msg)
 
-    @pytest.mark.order(10)
+    @pytest.mark.order(after="test_upstream_indexed_audio")
     def test_update_index_images(self):
         """Check that the image data can be updated from the API database into ES."""
 
@@ -483,7 +515,7 @@ class TestIngestion(unittest.TestCase):
         # Wait for the task to send us a callback.
         assert self.__class__.cb_queue.get(timeout=120) == "CALLBACK!"
 
-    @pytest.mark.order(11)
+    @pytest.mark.order(after="test_update_index_images")
     def test_update_index_audio(self):
         """Check that the audio data can be updated from the API database into ES."""
 
@@ -501,44 +533,60 @@ class TestIngestion(unittest.TestCase):
         # Wait for the task to send us a callback.
         assert self.__class__.cb_queue.get(timeout=120) == "CALLBACK!"
 
-    @pytest.mark.order(12)
+    @pytest.mark.order(after="test_update_index_audio")
     def test_index_deletion_succeeds(self):
         self._ingest_upstream("audio", "temporary")
         self._delete_index("audio", "temporary")
 
-    @pytest.mark.order(13)
+    @pytest.mark.order(after="test_index_deletion_succeeds")
     def test_alias_force_deletion_succeeds(self):
         self._ingest_upstream("audio", "temporary")
         self._promote("audio", "temporary", "audio-temp")
         self._delete_index("audio", "temporary", "audio-temp")
 
-    @pytest.mark.order(14)
+    @pytest.mark.order(after="test_alias_force_deletion_succeeds")
     def test_alias_soft_deletion_fails(self):
         self._ingest_upstream("audio", "temporary")
         self._promote("audio", "temporary", "audio-temp")
         self._soft_delete_index("audio", "audio-temp", "temporary")
 
-    @pytest.mark.order(15)
+    @pytest.mark.order(after="test_alias_soft_deletion_fails")
     def test_alias_ambiguous_deletion_fails(self):
         # No need to ingest or promote, index and alias exist
         self._soft_delete_index("audio", "audio-temp", "temporary", True)
 
-    @pytest.mark.order(16)
+    @pytest.mark.order(after="test_alias_ambiguous_deletion_fails")
     def test_stat_endpoint_for_index(self):
         res = requests.get(f"{ingestion_server}/stat/audio-integration")
         data = res.json()
         assert data["exists"]
         assert data["alt_names"] == ["audio-main"]
 
-    @pytest.mark.order(17)
+    @pytest.mark.order(after="test_stat_endpoint_for_index")
     def test_stat_endpoint_for_alias(self):
         res = requests.get(f"{ingestion_server}/stat/audio-main")
         data = res.json()
         assert data["exists"]
         assert data["alt_names"] == "audio-integration"
 
-    @pytest.mark.order(18)
+    @pytest.mark.order(after="test_stat_endpoint_for_alias")
     def test_stat_endpoint_for_non_existent(self):
         res = requests.get(f"{ingestion_server}/stat/non-existent")
         data = res.json()
         assert not data["exists"]
+
+    @pytest.mark.order(after="test_stat_endpoint_for_non_existent")
+    def test_create_filtered_image_index(self):
+        self._create_filtered_index("image")
+
+    @pytest.mark.order(after="test_create_filtered_image_index")
+    def test_point_filtered_image_alias(self):
+        self._point_alias("image", "integration-filtered", "image-filtered")
+
+    @pytest.mark.order(after="test_point_filtered_image_alias")
+    def test_create_filtered_audio_index(self):
+        self._create_filtered_index("audio")
+
+    @pytest.mark.order(after="test_create_filtered_audio_index")
+    def test_point_filtered_audio_alias(self):
+        self._point_alias("audio", "integration-filtered", "audio-filtered")

--- a/ingestion_server/test/integration_test.py
+++ b/ingestion_server/test/integration_test.py
@@ -468,6 +468,22 @@ class TestIngestion(unittest.TestCase):
         self._promote("audio", "integration", "audio-main")
 
     @pytest.mark.order(after="test_promote_audio")
+    def test_create_filtered_image_index(self):
+        self._create_filtered_index("image")
+
+    @pytest.mark.order(after="test_create_filtered_image_index")
+    def test_point_filtered_image_alias(self):
+        self._point_alias("image", "integration-filtered", "image-filtered")
+
+    @pytest.mark.order(after="test_point_filtered_image_alias")
+    def test_create_filtered_audio_index(self):
+        self._create_filtered_index("audio")
+
+    @pytest.mark.order(after="test_create_filtered_audio_index")
+    def test_point_filtered_audio_alias(self):
+        self._point_alias("audio", "integration-filtered", "audio-filtered")
+
+    @pytest.mark.order(after="test_point_filtered_audio_alias")
     def test_upstream_indexed_images(self):
         """
         Check that the image data has been successfully indexed in Elasticsearch.
@@ -574,19 +590,3 @@ class TestIngestion(unittest.TestCase):
         res = requests.get(f"{ingestion_server}/stat/non-existent")
         data = res.json()
         assert not data["exists"]
-
-    @pytest.mark.order(after="test_stat_endpoint_for_non_existent")
-    def test_create_filtered_image_index(self):
-        self._create_filtered_index("image")
-
-    @pytest.mark.order(after="test_create_filtered_image_index")
-    def test_point_filtered_image_alias(self):
-        self._point_alias("image", "integration-filtered", "image-filtered")
-
-    @pytest.mark.order(after="test_point_filtered_image_alias")
-    def test_create_filtered_audio_index(self):
-        self._create_filtered_index("audio")
-
-    @pytest.mark.order(after="test_create_filtered_audio_index")
-    def test_point_filtered_audio_alias(self):
-        self._point_alias("audio", "integration-filtered", "audio-filtered")

--- a/ingestion_server/test/integration_test.py
+++ b/ingestion_server/test/integration_test.py
@@ -468,22 +468,6 @@ class TestIngestion(unittest.TestCase):
         self._promote("audio", "integration", "audio-main")
 
     @pytest.mark.order(after="test_promote_audio")
-    def test_create_filtered_image_index(self):
-        self._create_filtered_index("image")
-
-    @pytest.mark.order(after="test_create_filtered_image_index")
-    def test_point_filtered_image_alias(self):
-        self._point_alias("image", "integration-filtered", "image-filtered")
-
-    @pytest.mark.order(after="test_point_filtered_image_alias")
-    def test_create_filtered_audio_index(self):
-        self._create_filtered_index("audio")
-
-    @pytest.mark.order(after="test_create_filtered_audio_index")
-    def test_point_filtered_audio_alias(self):
-        self._point_alias("audio", "integration-filtered", "audio-filtered")
-
-    @pytest.mark.order(after="test_point_filtered_audio_alias")
     def test_upstream_indexed_images(self):
         """
         Check that the image data has been successfully indexed in Elasticsearch.
@@ -590,3 +574,19 @@ class TestIngestion(unittest.TestCase):
         res = requests.get(f"{ingestion_server}/stat/non-existent")
         data = res.json()
         assert not data["exists"]
+
+    @pytest.mark.order(after="test_stat_endpoint_for_non_existent")
+    def test_create_filtered_image_index(self):
+        self._create_filtered_index("image")
+
+    @pytest.mark.order(after="test_create_filtered_image_index")
+    def test_point_filtered_image_alias(self):
+        self._point_alias("image", "integration-filtered", "image-filtered")
+
+    @pytest.mark.order(after="test_point_filtered_image_alias")
+    def test_create_filtered_audio_index(self):
+        self._create_filtered_index("audio")
+
+    @pytest.mark.order(after="test_create_filtered_audio_index")
+    def test_point_filtered_audio_alias(self):
+        self._point_alias("audio", "integration-filtered", "audio-filtered")


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Related to https://github.com/WordPress/openverse-api/issues/588 by @zackkrida
Fixes https://github.com/WordPress/openverse-api/issues/1109 by @obulat (at least potentially, based on loose decisions we made last week during offline chats)

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Adds a new settings variable, `SENSITIVE_TERMS`. It should be a comma separated list of terms to exclude, parsed on application startup. This variable exists for both the ingestion server and the Django API.

In the ingestion server, the terms are used to create a filtered index via the reindex API. I've updated `load_sample_data.sh` to created this filtered index and allow for easy local testing. Note that the filtered index uses the terms "dog" and "water".

In the Django API, the terms are excluded from search via an inverted `MultiMatch` query. The approach is naive and may perform poorly in production. It may be necessary to connect a local box to the production Elasticsearch to try a query with "dog" excluded, for example, to see how it performs (or some other way to test, maybe using staging Elasticsearch cluster, cc @AetherUnbound @obulat @krysal who may all have better ideas for how to safely test). I also don't know if this will scale if we have, say, 100 or so terms. I'd wager it should be fine, but it's a completely naive guess founded on essentially nothing other than trusting Elasticsearch's ability to aggregate such queries.

I don't know if this is the right approach. The significant alternative I can imagine is to store the list of terms in Postgres and caching their retrieval by 30 minutes to an hour (potentially busting the cache immediately when the model saves). This would allow us to change the terms without needing to redeploy. It makes sharing the list slightly harder because we'd have to give Django Admin access or export it from Django Admin. Leaving it as an environment variable allows the sharer to copy/paste the list out of the private infrastructure repository instead. 
A production redeployment currently takes ~10 minutes and are tedious now but will be easier (and faster when staying on the same version) in the future once the ECS migration is completed.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

By default, local environment is set up with two excluded terms for the filtered index: "dog" and "water". For the Django API, the excluded terms are "spoiled" and "perched". I'd advise searching these terms on `main` first, before running this branch, and noting the result counts and such for related queries. I tested using images so the following instructions only include specifics for images, but the same principles will apply for audio.

Make a query for "dog" and "water" and pick out a separate word that would hit that document. For example, "running" will include 2 "water" documents (amongst others of people running).

Afterwards, run this branch and make the same queries with `mature=True` and `mature=False` (the latter being the default). You should see different behaviour. When mature results are excluded, for "running", you should get 2 less documents, equivalent to searching "running -water". For "dogs" you should get no documents. When mature results are included via the query parameter, you'll receive the same results as on `main`.

Again, those are for the images index, but the same principles will apply for audio.

To test the API terms, follow the same pattern of testing, but use the terms listed above for the query-time feature instead of the filtered index feature.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
