### PR TITLE
Tally top 80 results exactly and fix "monday" timestamp calculation

### DIFF
--- a/api/catalog/api/controllers/search_controller.py
+++ b/api/catalog/api/controllers/search_controller.py
@@ -414,10 +414,33 @@ def search(
         search_response, results, page_size, page
     )
 
-    if results and page <= 4:
-        # We ignore tallies for deep pages because they're not likely to
+    max_result_depth = page * page_size
+    if max_result_depth <= 80:
+        # Applies when `page_size * page` could land "evenly" on 80
+        should_tally = True
+        results_to_tally = results
+    elif max_result_depth - page_size < 80:
+        # Applies when `page_size * page` could land beyond 80, but still
+        # encompas on _this page_ some results that are below the 80th
+        # position. For example: page=7 page_size=12 result depth=84.
+        # While max_result_depth exceeds 80, we still want to count
+        # the first eight results in `results` that are below or at the 80th
+        # position for the query.
+        should_tally = True
+        results_to_tally = results[: 80 - (max_result_depth - page_size)]
+    else:
+        should_tally = False
+
+    if should_tally:
+        # We ignore tallies for deep results because they're not likely to
         # be as important for search relevancy for most users at this point
-        tallies.count_provider_occurrences(results, index)
+        # 80 is chosen because it represents the first four pages of the
+        # default page count of 20 (20 * 4) which is how our own frontend
+        # makes requests and displays results. Because that is the only
+        # place we can actually conceivably measure relevancy down the
+        # line, it is the only sensible, controlled space we can use to
+        # check things like provider density for a set of queries.
+        tallies.count_provider_occurrences(results_to_tally, index)
 
     return results or [], page_count, result_count
 

--- a/api/catalog/api/controllers/search_controller.py
+++ b/api/catalog/api/controllers/search_controller.py
@@ -421,7 +421,7 @@ def search(
         results_to_tally = results
     elif max_result_depth - page_size < 80:
         # Applies when `page_size * page` could land beyond 80, but still
-        # encompas on _this page_ some results that are below the 80th
+        # encompass some results on _this page_ that are at or below the 80th
         # position. For example: page=7 page_size=12 result depth=84.
         # While max_result_depth exceeds 80, we still want to count
         # the first eight results in `results` that are below or at the 80th
@@ -431,7 +431,7 @@ def search(
     else:
         should_tally = False
 
-    if should_tally:
+    if results and should_tally:
         # We ignore tallies for deep results because they're not likely to
         # be as important for search relevancy for most users at this point
         # 80 is chosen because it represents the first four pages of the

--- a/api/catalog/api/utils/tallies.py
+++ b/api/catalog/api/utils/tallies.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import django_redis
 from django_redis.client.default import Redis
@@ -8,12 +8,8 @@ from django_redis.client.default import Redis
 def _get_weekly_timestamp() -> str:
     """Get a timestamp for the Monday of any given week."""
     now = datetime.now()
-    return datetime(
-        now.year,
-        now.month,
-        # Set the day to Monday of the current week
-        now.day - now.weekday(),
-    ).strftime("%Y-%m-%d")
+    monday = now - timedelta(days=now.weekday())
+    return monday.strftime("%Y-%m-%d")
 
 
 def count_provider_occurrences(results: list[dict], index: str) -> None:


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->
Staci and I noticed two issues while we were deploying the API today:

1. If the page_size changes (for example to 200), then if we tally the first 4 pages, we'd be tallying the top 800 results, which does not really reflect the intention of the tallying (for seeing the provider density of "top results"
2. On weeks that include a month boundary, the "monday" date stamp calculation was incorrect. We only found this because we were working on this literally as 00:00 UTC 1 Feb 2023 rolled over from January!

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

Applies fixes for the above described issues. There are (hopefully) sufficient comments to hopefully describe the approach and intentions as the logic is a bit convoluted.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Check out the much expanded unit tests. You can test locally following the process Staci describes here: https://github.com/WordPress/openverse-api/pull/1088#pullrequestreview-1266702601. However, because local results for any given query do not really have 80 results, you'll need to test without a query or with a `*` query.

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
