### PR TITLE
Include image tag in built image

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -51,9 +51,9 @@ jobs:
         id: get-image-tag
         run: |
           if [[ "${{ github.event_name }}" == "release" ]]; then
-              echo "image-tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+              echo "image-tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
           else
-              echo "image-tag=${{ github.sha }}" >> $GITHUB_OUTPUT
+              echo "image-tag=${{ github.sha }}" >> "$GITHUB_OUTPUT"
           fi
 
   build-images:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -41,6 +41,21 @@ jobs:
           pip install pre-commit
           pre-commit run --all-files
 
+  get-image-tag:
+    name: Get image tag
+    runs-on: ubuntu-latest
+    outputs:
+      image-tag: ${{ steps.get-image-tag.outputs.image-tag }}
+    steps:
+      - name: Get image tag
+        id: get-image-tag
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+              echo "image-tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          else
+              echo "image-tag=${{ github.sha }}" >> $GITHUB_OUTPUT
+          fi
+
   build-images:
     name: Build images
     runs-on: ubuntu-latest
@@ -49,6 +64,7 @@ jobs:
         image:
           - api
           - ingestion_server
+    needs: get-image-tag
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -67,6 +83,8 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,scope=${{ matrix.image }}
           outputs: type=docker,dest=/tmp/${{ matrix.image }}.tar
+          build-args: |
+            SEMANTIC_VERSION=${{ needs.get-image-tag.outputs.image-tag }}
 
       - name: Upload image `${{ matrix.image }}`
         uses: actions/upload-artifact@v3
@@ -80,6 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-images
+      - get-image-tag
 
     steps:
       - uses: actions/checkout@v3
@@ -120,6 +139,8 @@ jobs:
           cache-from: type=gha,scope=nginx
           cache-to: type=gha,scope=nginx
           outputs: type=docker,dest=/tmp/api-nginx.tar
+          build-args: |
+            SEMANTIC_VERSION=${{ needs.get-image-tag.outputs.image-tag }}
 
       - name: Upload image `api-nginx`
         uses: actions/upload-artifact@v3
@@ -351,6 +372,7 @@ jobs:
     needs:
       - test-ing
       - test-api
+      - get-image-tag
       - build-nginx
     permissions:
       packages: write
@@ -381,14 +403,7 @@ jobs:
           docker tag openverse-${{ matrix.image }} \
             ghcr.io/wordpress/openverse-${{ matrix.image }}:latest
           docker tag openverse-${{ matrix.image }} \
-            ghcr.io/wordpress/openverse-${{ matrix.image }}:${{ github.sha }}
-          docker push --all-tags ghcr.io/wordpress/openverse-${{ matrix.image }}
-
-      - name: Tag image `${{ matrix.image }}` (release)
-        if: github.event_name == 'release'
-        run: |
-          docker tag openverse-${{ matrix.image }} \
-            ghcr.io/wordpress/openverse-${{ matrix.image }}:${{ github.ref_name }}
+            ghcr.io/wordpress/openverse-${{ matrix.image }}:${{ needs.get-image-tag.outputs.image-tag }}
           docker push --all-tags ghcr.io/wordpress/openverse-${{ matrix.image }}
 
   deploy-staging:
@@ -396,14 +411,15 @@ jobs:
     runs-on: ubuntu-latest
     # Deploy a new version when `main` is pushed to in this repository
     if: github.event_name == 'push' && github.repository == 'WordPress/openverse-api'
-    needs: push
-
+    needs:
+      - push
+      - get-image-tag
     steps:
       - uses: actions/checkout@v3
 
       - uses: ./.github/actions/staging-deploy
         with:
-          tag: ${{ github.sha }}
+          tag: ${{ needs.get-image-tag.outputs.image-tag }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -64,7 +64,9 @@ jobs:
         image:
           - api
           - ingestion_server
-    needs: get-image-tag
+    needs:
+      - get-image-tag
+      - lint
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -51,6 +51,9 @@ COPY /static /app/static
 # Only environment variables with this prefix will be available in the template
 ENV NGINX_ENVSUBST_FILTER="DJANGO_NGINX_"
 ENV DJANGO_NGINX_ENVIRONMENT="local"
+# Add the release version to the docker container
+ARG SEMANTIC_VERSION
+ENV DJANGO_NGINX_GIT_REVISION=$SEMANTIC_VERSION
 
 #######
 # API #
@@ -89,6 +92,10 @@ USER opener
 
 # Copy code into the final image
 COPY --chown=opener . /api/
+
+# Add the release version to the docker container
+ARG SEMANTIC_VERSION
+ENV SEMANTIC_VERSION=$SEMANTIC_VERSION
 
 # Exposes
 # - 8000: Dev server for API Django app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,10 @@ services:
       - es-data:/usr/share/elasticsearch/data
 
   web:
-    build: ./api/
+    build:
+      context: ./api/
+      args:
+        SEMANTIC_VERSION: ${SEMANTIC_VERSION:-v1.0.0}
     image: openverse-api
     volumes:
       - ./api:/api


### PR DESCRIPTION
## Fixes

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes https://github.com/WordPress/openverse-infrastructure/issues/332 by @AetherUnbound

## Description

<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->

This PR changes the API and API nginx images to include the image tag as a part of the built docker images, so it can be referenced appropriately once the service is deployed without having to alter the ECS task definition every time.

The logic I've added _should_ use the github SHA as the `SEMANTIC_VERSION` for all pushes to main, but use the ref name (e.g. tag version like "v2.5.10") for all releases.

## Testing Instructions

<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

Very hard to test GitHub actions, this is based off of similar work on the frontend so I'm hoping it works!

## Checklist

<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like
      `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or
      a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no visible
      errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
