### PR TITLE
Use upstream thumbnail if available

### DIFF
--- a/api/catalog/api/views/image_views.py
+++ b/api/catalog/api/views/image_views.py
@@ -1,5 +1,4 @@
 import io
-import re
 import struct
 
 from django.conf import settings
@@ -108,16 +107,9 @@ class ImageViewSet(MediaViewSet):
     def thumbnail(self, request, *_, **__):
         image = self.get_object()
 
-        image_url = image.url
+        image_url = image.thumbnail or image.url
         if not image_url:
             raise NotFound("Could not find image.", 404)
-
-        # Hotfix to use scaled down version of the image from SMK
-        # TODO Remove when this issue is addressed:
-        # TODO https://github.com/WordPress/openverse-catalog/issues/698
-        if "iip.smk.dk" in image_url:
-            width = settings.THUMBNAIL_WIDTH_PX
-            image_url = re.sub(r"!\d+,", f"!{width},", image_url)
 
         return super().thumbnail(image_url, request)
 

--- a/api/test/unit/views/image_views_test.py
+++ b/api/test/unit/views/image_views_test.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from test.factory.models.image import ImageFactory
+from unittest.mock import patch
 
 import pytest
 from requests import Request, Response
@@ -56,3 +57,15 @@ def test_oembed_sends_ua_header(api_client, requests):
     assert len(requests.requests) > 0
     for r in requests.requests:
         assert r.headers == ImageViewSet.OEMBED_HEADERS
+
+
+@pytest.mark.django_db
+def test_thumbnail_uses_upstream_thumb(api_client):
+    image = ImageFactory.create()
+    with patch("catalog.api.views.media_views.photon.get") as photon_patch:
+        api_client.get(f"/v1/images/{image.identifier}/thumbnail/")
+
+        # This is throwing "Called 0 times."
+        photon_patch.assert_called_once()
+        # A photon_patch.assert_called_once_with(image_url=image.thumbnail, ...)
+        # or something similar should follow after the above call passes.


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please consider opening one before creating this pull request. -->

Fixes #896 by @stacimc

## Description
<!-- Concisely describe what the pull request does. -->
<!-- Add screenshots, videos, or other media to show the problem and the solution when appropriate. -->
Sends the URL of the upstream thumbnail to Photon if available, so we can get the thumbnail faster and prevent timing out in some extreme cases.

The code change itself is pretty simple but I'm having a hard time testing this automatically so any help in this regard is welcome here. Maybe someone can observe something I'm missing or come up with a better idea.

## Testing Instructions
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
To manually test this you can pick any image from the database that has a thumbnail (applies for Flickr and Stocksnap) and compare the result of the `http://localhost:50280/v1/images/<identifier>/thumb/` endpoint to its `url`. Observe the difference in sizes. On the `main` branch, you will get the same image.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main`) or a parent feature branch.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [WIP] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:
  https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

## Developer Certificate of Origin

<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
